### PR TITLE
feat: expose `sha256base64` utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { objectHash } from "./object-hash";
 export { hash } from "./hash";
 export { murmurHash } from "./crypto/murmur";
-export { sha256 } from "./crypto/sha256";
+export { sha256, sha256base64 } from "./crypto/sha256";
 export { isEqual } from "./utils";


### PR DESCRIPTION
Function `sha256base64` isn't exported.