### PR TITLE
perf(object-hash): faster isNativeFunction check

### DIFF
--- a/src/object-hash.ts
+++ b/src/object-hash.ts
@@ -375,11 +375,15 @@ function createHasher(options: HashOptions) {
   };
 }
 
+const nativeFunc = "[native code] }";
+const nativeFuncLength = nativeFunc.length;
+
 /** Check if the given function is a native function */
 function isNativeFunction(f) {
   if (typeof f !== "function") {
     return false;
   }
-  const exp = /^function\s+\w*\s*\(\s*\)\s*{\s+\[native code]\s+}$/i;
-  return exp.exec(Function.prototype.toString.call(f)) != null;
+  return (
+    Function.prototype.toString.call(f).slice(-nativeFuncLength) === nativeFunc
+  );
 }


### PR DESCRIPTION
Inspired by https://github.com/puleos/object-hash/pull/122

### perf: faster isNativeFunction check

Use slice to check if the native function instead of using regex.

```
'oldRegex x 13,961,935 ops/sec ±2.56% (83 runs sampled)',
'endsWith x 43,583,325 ops/sec ±0.46% (94 runs sampled)',
'slice x 1,133,185,926 ops/sec ±0.59% (93 runs sampled)',
'for x 160,559,673 ops/sec ±0.15% (93 runs sampled)'
```

> Benchmark: [bench-is-native-function.js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-is-native-function-js)