### PR TITLE
perf(object-hash): faster extract object type from toString

### DIFF
--- a/src/object-hash.ts
+++ b/src/object-hash.ts
@@ -94,13 +94,20 @@ function createHasher(options: HashOptions) {
         return this._object(object.toJSON());
       }
 
-      const pattern = /\[object (.*)]/i;
       const objString = Object.prototype.toString.call(object);
 
-      const _objType = pattern.exec(objString);
-      const objType = _objType
-        ? _objType[1].toLowerCase() // take only the class name
-        : "unknown:[" + objString.toLowerCase() + "]"; // object type did not match [object ...]
+      let objType = "";
+      const objectLength = objString.length;
+
+      // '[object a]'.length === 10, the minimum
+      if (objectLength < 10) {
+        objType = "unknown:[" + objString + "]";
+      } else {
+        // '[object '.length === 8
+        objType = objString.slice(8, objectLength - 1);
+      }
+
+      objType = objType.toLowerCase();
 
       let objectNumber = null;
 


### PR DESCRIPTION
Inspired by https://github.com/puleos/object-hash/pull/122

### perf: faster extract object type from toString

Using slice again instead of Regex.

```
'oldRegex x 12,546,910 ops/sec ±2.65% (81 runs sampled)',
'slice x 1,135,283,250 ops/sec ±0.30% (97 runs sampled)'
```

> Benchmark: [bench-object-type.js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-object-type-js)
