### PR TITLE
perf(object-hash): avoid unnecessary `.toString()` on known values

### DIFF
--- a/src/object-hash.ts
+++ b/src/object-hash.ts
@@ -208,11 +208,11 @@ function createHasher(options: HashOptions) {
       return write("error:" + err.toString());
     },
     _boolean(bool) {
-      return write("bool:" + bool.toString());
+      return write("bool:" + bool);
     },
     _string(string) {
       write("string:" + string.length + ":");
-      write(string.toString());
+      write(string);
     },
     _function(fn) {
       write("fn:");
@@ -234,7 +234,7 @@ function createHasher(options: HashOptions) {
       }
     },
     _number(number) {
-      return write("number:" + number.toString());
+      return write("number:" + number);
     },
     _xml(xml) {
       return write("xml:" + xml.toString());


### PR DESCRIPTION
Inspired by https://github.com/puleos/object-hash/pull/122

###  perf: avoid toString when we know that the value is already a string

I did some tests and some values are fast by just leaving `'string' + value`, other values are slow, so I only change the values that shows a significant improvement.

```
'with toString x 243,790,997 ops/sec ±4.95% (88 runs sampled)',
'without toString x 1,138,995,770 ops/sec ±0.12% (94 runs sampled)',
'bool: with toString x 222,584,175 ops/sec ±0.11% (97 runs sampled)',
'bool: without toString x 1,142,979,415 ops/sec ±0.46% (94 runs sampled)',
'number: with toString x 110,618,185 ops/sec ±0.48% (94 runs sampled)',
'number: without toString x 1,148,295,991 ops/sec ±0.05% (99 runs sampled)',
'url: with toString x 11,248,050 ops/sec ±1.76% (84 runs sampled)',
'url: without toString x 4,678,286 ops/sec ±0.95% (94 runs sampled)',
'bigint: with toString x 24,012,147 ops/sec ±1.97% (87 runs sampled)',
'bigint: without toString x 15,661,883 ops/sec ±2.36% (78 runs sampled)'
```

> Benchmark: [bench-to-string.js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-to-string-js)
