### PR TITLE
perf(object-hash): avoid splice method to insert values

### DIFF
--- a/src/object-hash.ts
+++ b/src/object-hash.ts
@@ -68,7 +68,11 @@ export function objectHash(object: any, options: HashOptions = {}): string {
   return hasher.toString();
 }
 
-const defaultPrototypesKeys = Object.freeze(["prototype", "__proto__", "constructor"]);
+const defaultPrototypesKeys = Object.freeze([
+  "prototype",
+  "__proto__",
+  "constructor",
+]);
 
 function createHasher(options: HashOptions) {
   const buff: string[] = [];

--- a/src/object-hash.ts
+++ b/src/object-hash.ts
@@ -68,6 +68,8 @@ export function objectHash(object: any, options: HashOptions = {}): string {
   return hasher.toString();
 }
 
+const defaultPrototypesKeys = Object.freeze(["prototype", "__proto__", "constructor"]);
+
 function createHasher(options: HashOptions) {
   const buff: string[] = [];
   let context = [];
@@ -134,27 +136,37 @@ function createHasher(options: HashOptions) {
         if (options.unorderedObjects) {
           keys = keys.sort();
         }
+        let extraKeys = [];
         // Make sure to incorporate special properties, so Types with different prototypes will produce
         // a different hash and objects derived from different functions (`new Foo`, `new Bar`) will
         // produce different hashes. We never do this for native functions since some seem to break because of that.
         if (options.respectType !== false && !isNativeFunction(object)) {
-          keys.splice(0, 0, "prototype", "__proto__", "letructor");
+          extraKeys = defaultPrototypesKeys;
         }
 
         if (options.excludeKeys) {
           keys = keys.filter(function (key) {
             return !options.excludeKeys(key);
           });
+          extraKeys = extraKeys.filter(function (key) {
+            return !options.excludeKeys(key);
+          });
         }
 
-        write("object:" + keys.length + ":");
-        for (const key of keys) {
+        write("object:" + (keys.length + extraKeys.length) + ":");
+        const dispatchForKey = (key) => {
           this.dispatch(key);
           write(":");
           if (!options.excludeValues) {
             this.dispatch(object[key]);
           }
           write(",");
+        };
+        for (const key of keys) {
+          dispatchForKey(key);
+        }
+        for (const key of extraKeys) {
+          dispatchForKey(key);
         }
       }
     },


### PR DESCRIPTION
Inspired by https://github.com/puleos/object-hash/pull/122

### perf: avoid splice method to insert values

If possible, I prefer to avoid splice and any other method to modify the array is is possible.

```
'splice x 8,139,878 ops/sec ±1.25% (89 runs sampled)',
'unshift x 7,932,324 ops/sec ±0.97% (94 runs sampled)',
'Array.prototype.push.apply x 14,664,082 ops/sec ±1.09% (90 runs sampled)'
```

> Benchmark: [bench-splice-vs-push-js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-splice-vs-push-js)
