### PR TITLE
perf(object-hash): avoid using array to just concatenate the string

### DIFF
--- a/src/object-hash.ts
+++ b/src/object-hash.ts
@@ -69,15 +69,15 @@ export function objectHash(object: any, options: HashOptions = {}): string {
 }
 
 function createHasher(options: HashOptions) {
-  const buff: string[] = [];
+  let buff = "";
   let context = [];
   const write = (str: string) => {
-    buff.push(str);
+    buff += str;
   };
 
   return {
     toString() {
-      return buff.join("");
+      return buff;
     },
     getContext() {
       return context;


### PR DESCRIPTION
Instead of concatenating all the strings every time we call `toString`, just concatenate every time `write` is called:

```
hash({}) x 638,508 ops/sec ±1.21% (89 runs sampled)
hash(singleObject) x 94,972 ops/sec ±0.77% (93 runs sampled)
hash(tinyArray) x 10,008 ops/sec ±1.14% (90 runs sampled)
hash(mediumArray) x 961 ops/sec ±1.70% (89 runs sampled)
hash(largeArray) x 61.54 ops/sec ±1.55% (63 runs sampled)
hash(largeJson) x 1.90 ops/sec ±0.87% (9 runs sampled)
objectHash(largeJson, { unorderedObjects: true }) x 1.90 ops/sec ±0.76% (9 runs sampled)
```

To:

```
hash({}) x 789,862 ops/sec ±1.21% (88 runs sampled)
hash(singleObject) x 107,655 ops/sec ±1.33% (88 runs sampled)
hash(tinyArray) x 11,503 ops/sec ±0.84% (90 runs sampled)
hash(mediumArray) x 1,146 ops/sec ±1.08% (90 runs sampled)
hash(largeArray) x 69.77 ops/sec ±1.97% (65 runs sampled)
hash(largeJson) x 1.64 ops/sec ±1.69% (9 runs sampled)
objectHash(largeJson, { unorderedObjects: true }) x 1.61 ops/sec ±2.43% (9 runs sampled)
```

It's good for tiny objects but degrades a little bit for larger objects (for some reason I don't know exactly)