### PR TITLE
fix(murmurHash): fix murmurHash3 implementation, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Usage:
 ```js
 import { murmurHash } from "ohash";
 
-// "2708020327"
+// "427197390"
 console.log(murmurHash("Hello World"));
 ```
 

--- a/src/crypto/murmur.ts
+++ b/src/crypto/murmur.ts
@@ -50,11 +50,11 @@ export function murmurHash(key: Uint8Array | string, seed = 0) {
   switch (remainder) {
     case 3: {
       k1 ^= (key[i + 2] & 0xff) << 16;
-      break;
+      /* falls through */
     }
     case 2: {
       k1 ^= (key[i + 1] & 0xff) << 8;
-      break;
+      /* falls through */
     }
     case 1: {
       k1 ^= key[i] & 0xff;

--- a/src/crypto/murmur.ts
+++ b/src/crypto/murmur.ts
@@ -1,7 +1,7 @@
 /**
  * JS Implementation of MurmurHash3 (r136) (as of May 20, 2011)
  *
- * @param {Uint8Array | string} key ASCII only
+ * @param {Uint8Array | string} key
  * @param {number} seed Positive integer only
  * @return {number} 32-bit positive integer hash
  */

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -65,6 +65,9 @@ describe("murmurHash", () => {
       "3581961153",
     );
   });
+  it("Gives correct hash with uint32 maximum value as seed", () => {
+    expect(murmurHash("a", 2_147_483_647)).toMatchInlineSnapshot("3574244913");
+  });
 });
 
 it("sha256", () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -34,17 +34,37 @@ describe("objectHash", () => {
   });
 });
 
-it("murmurHash", () => {
-  expect(murmurHash("Hello World")).toMatchInlineSnapshot("427197390");
-  expect(murmurHash("a")).toMatchInlineSnapshot("1009084850");
-  expect(murmurHash("aa")).toMatchInlineSnapshot("923832745");
-  expect(murmurHash("aaa")).toMatchInlineSnapshot("3033554871");
-  expect(murmurHash("aaaa")).toMatchInlineSnapshot("2129582471");
-  expect(murmurHash("aaaaa")).toMatchInlineSnapshot("3922341931");
-  expect(murmurHash("aaaaaa")).toMatchInlineSnapshot("1736445713");
-  expect(murmurHash("aaaaaaa")).toMatchInlineSnapshot("1497565372");
-  expect(murmurHash("aaaaaaaa")).toMatchInlineSnapshot("3662943087");
-  expect(murmurHash("aaaaaaaaa")).toMatchInlineSnapshot("2724714153");
+describe("murmurHash", () => {
+  it("Generates correct hash for 0 bytes without seed", () => {
+    expect(murmurHash("")).toMatchInlineSnapshot("0");
+  });
+  it("Generates correct hash for 0 bytes with seed", () => {
+    expect(murmurHash("", 1)).toMatchInlineSnapshot("1364076727"); // 0x514E28B7
+  });
+  it("Generates correct hash for 'Hello World'", () => {
+    expect(murmurHash("Hello World")).toMatchInlineSnapshot("427197390");
+  });
+  it("Generates the correct hash for varios string lengths", () => {
+    expect(murmurHash("a")).toMatchInlineSnapshot("1009084850");
+    expect(murmurHash("aa")).toMatchInlineSnapshot("923832745");
+    expect(murmurHash("aaa")).toMatchInlineSnapshot("3033554871");
+    expect(murmurHash("aaaa")).toMatchInlineSnapshot("2129582471");
+    expect(murmurHash("aaaaa")).toMatchInlineSnapshot("3922341931");
+    expect(murmurHash("aaaaaa")).toMatchInlineSnapshot("1736445713");
+    expect(murmurHash("aaaaaaa")).toMatchInlineSnapshot("1497565372");
+    expect(murmurHash("aaaaaaaa")).toMatchInlineSnapshot("3662943087");
+    expect(murmurHash("aaaaaaaaa")).toMatchInlineSnapshot("2724714153");
+  });
+  it("Works with Uint8Arrays", () => {
+    expect(
+      murmurHash(new Uint8Array([0x21, 0x43, 0x65, 0x87])),
+    ).toMatchInlineSnapshot("4116402539"); // 0xF55B516B
+  });
+  it("Handles UTF-8 high characters correctly", () => {
+    expect(murmurHash("ππππππππ", 0x97_47_b2_8c)).toMatchInlineSnapshot(
+      "3581961153",
+    );
+  });
 });
 
 it("sha256", () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -35,7 +35,16 @@ describe("objectHash", () => {
 });
 
 it("murmurHash", () => {
-  expect(murmurHash("Hello World")).toMatchInlineSnapshot("2708020327");
+  expect(murmurHash("Hello World")).toMatchInlineSnapshot("427197390");
+  expect(murmurHash("a")).toMatchInlineSnapshot("1009084850");
+  expect(murmurHash("aa")).toMatchInlineSnapshot("923832745");
+  expect(murmurHash("aaa")).toMatchInlineSnapshot("3033554871");
+  expect(murmurHash("aaaa")).toMatchInlineSnapshot("2129582471");
+  expect(murmurHash("aaaaa")).toMatchInlineSnapshot("3922341931");
+  expect(murmurHash("aaaaaa")).toMatchInlineSnapshot("1736445713");
+  expect(murmurHash("aaaaaaa")).toMatchInlineSnapshot("1497565372");
+  expect(murmurHash("aaaaaaaa")).toMatchInlineSnapshot("3662943087");
+  expect(murmurHash("aaaaaaaaa")).toMatchInlineSnapshot("2724714153");
 });
 
 it("sha256", () => {


### PR DESCRIPTION
## Changes:

   * Fixes the `murmurHash` implementation by falling through all remainders as intended, instead of breaking.
   * Removes an outdated JSDoc comment stating ASCII only for the data parameter, while it does in fact encode JavaScript strings using UTF-8 through TextEncoder().encode(), which matches how most other implementations do it.
   * Updates the hash value produced by `murmurHash` in the README example.
   * To prevent regression bugs, some basic test cases are added, covering seeds, UTF-8, Uint8Arrays, different input lengths, and the maximum safe seed value.
   * Ensures compatibility with other implementations through testing known inputs, seeds, and outputs.

## Please note:

About 50% of the hashes produced by `murmurHash` prior to this fix are incorrect, so handle with care.

## Additional notes:

Resolves #82 and #11