### PR TITLE
build!: esm only

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Import:
 // ESM
 import { hash, objectHash, sha256 } from "ohash";
 
-// CommonJS
-const { hash, objectHash, sha256 } = require("ohash");
+// Or dnamic import in strict CommonJS contexts
+const { hash, objectHash, sha256 } = await import("ohash");
 ```
 
 ### `hash(object, options?)`

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     },
     "./crypto": {
       "node": {
-        "types": "./dist/crypto/node/index.mjs",
+        "types": "./dist/crypto/node/index.d.mts",
         "default": "./dist/crypto/node/index.mjs"
       },
       "default": {
-        "types": "./dist/crypto/js/index.mjs",
+        "types": "./dist/crypto/js/index.d.mts",
         "default": "./dist/crypto/js/index.mjs"
       }
     }

--- a/package.json
+++ b/package.json
@@ -8,24 +8,21 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs"
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
     },
     "./crypto": {
       "node": {
-        "import": "./dist/crypto/node/index.mjs",
-        "require": "./dist/crypto/node/index.cjs"
+        "types": "./dist/crypto/node/index.mjs",
+        "default": "./dist/crypto/node/index.mjs"
       },
       "default": {
-        "import": "./dist/crypto/js/index.mjs",
-        "require": "./dist/crypto/js/index.cjs"
+        "types": "./dist/crypto/js/index.mjs",
+        "default": "./dist/crypto/js/index.mjs"
       }
     }
   },
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This PR makes the package size 1/2 by dropping legacy CommonJS support.

With Node.js and modern runtimes allowing mixed CommonJS + ESM usage, it should be less concern.

