### PR TITLE
refactor!: rename `sha256*` to `stringDigest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ Import:
 
 ```js
 // ESM import
-import { hash, objectHash, sha256 } from "ohash";
+import { hash, objectHash, stringDigest } from "ohash";
 
 // ..or dnamic import
-const { hash, objectHash, sha256 } = await import("ohash");
+const { hash, objectHash, stringDigest } = await import("ohash");
 ```
 
 ### `hash(object, options?)`
 
-Converts object value into a string hash using `objectHash` and then applies `sha256` with Base64 encoding (trimmed by length of 10).
+Serializes any value into a string hash using `objectHash` and then hashes result sha256+base64 (using `stringDigest`) trimmed by length of `10`.
 
 **Usage:**
 
@@ -124,26 +124,19 @@ const diff = diff(obj1, obj2);
 console.log(diff(obj1, obj2));
 ```
 
-### `sha256`
+### `stringDigest`
 
-Create a [sha256](https://en.wikipedia.org/wiki/SHA-2) digest from input string.
+Create a [sha256](https://en.wikipedia.org/wiki/SHA-2) digest from input and returns the hash as a base64 string.
 
-```js
-import { sha256 } from "ohash";
+> [!IMPORTANT]
+> The `+`, `/`, and `=` characters are removed from base64 result to maximize compatibility.
+> This behavior differs from standard SHA-256 + Base64 encoding.
 
-// "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e"
-console.log(sha256("Hello World"));
-```
-
-### `sha256base64`
-
-Create a [sha256](https://en.wikipedia.org/wiki/SHA-2) digest in Base64 encoding from input string.
-
-```js
-import { sha256base64 } from "ohash";
+```ts
+import { stringDigest } from "ohash";
 
 // "pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4"
-console.log(sha256base64("Hello World"));
+console.log(stringDigest("Hello World"));
 ```
 
 ## 💻 Development

--- a/src/crypto/js/index.ts
+++ b/src/crypto/js/index.ts
@@ -1,1 +1,12 @@
-export { sha256, sha256base64 } from "./sha256";
+import { Base64 } from "./_core";
+import { SHA256 } from "./sha256";
+
+/**
+ * Hashes string using SHA-256 algorithm and returns the hash as a base64 string.
+ *
+ * **Note:** The `+`, `/`, and `=` characters are removed from the base64 result to maximize compatibility.
+ * This behavior differs from standard SHA-256 + Base64 encoding.
+ */
+export function stringDigest(message: string) {
+  return new SHA256().finalize(message).toString(Base64);
+}

--- a/src/crypto/js/sha256.ts
+++ b/src/crypto/js/sha256.ts
@@ -147,13 +147,3 @@ export class SHA256 extends Hasher {
 export function sha256(message: string) {
   return new SHA256().finalize(message).toString();
 }
-
-/**
- * Calculates the SHA-256 hash of the given message and encodes it in Base64.
- *
- * @param {string} message - The message to hash.
- * @returns {string} The base64 encoded hash of the message.
- */
-export function sha256base64(message: string) {
-  return new SHA256().finalize(message).toString(Base64);
-}

--- a/src/crypto/node/index.ts
+++ b/src/crypto/node/index.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
 
-export function sha256(data: string): string {
-  return createHash("sha256").update(data).digest("hex").replace(/=+$/, "");
-}
-
-export function sha256base64(date: string): string {
+/**
+ * Hashes string using SHA-256 algorithm and returns the hash as a base64 string.
+ *
+ * **Note:** The `+`, `/`, and `=` characters are removed from the base64 result to maximize compatibility.
+ * This behavior differs from standard SHA-256 + Base64 encoding.
+ */
+export function stringDigest(date: string): string {
   return createHash("sha256")
     .update(date)
     .digest("base64")

--- a/src/hash/hash.ts
+++ b/src/hash/hash.ts
@@ -1,8 +1,9 @@
 import { objectHash, type HashOptions } from "./object-hash";
-import { sha256base64 } from "ohash/crypto";
+import { stringDigest } from "ohash/crypto";
 
 /**
- * Hash any JS value into a string
+ * Hash any JS value into a string.
+ *
  * @param {object} object value to hash
  * @param {HashOptions} options hashing options. See {@link HashOptions}.
  * @return {string} hash value
@@ -11,5 +12,5 @@ import { sha256base64 } from "ohash/crypto";
 export function hash(object: any, options: HashOptions = {}): string {
   const hashed =
     typeof object === "string" ? object : objectHash(object, options);
-  return sha256base64(hashed).slice(0, 10);
+  return stringDigest(hashed).slice(0, 10);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { objectHash } from "./hash/object-hash";
 export { hash } from "./hash/hash";
 
 // Crypto
-export { sha256, sha256base64 } from "./crypto/js/sha256";
+export { stringDigest } from "ohash/crypto";
 
 // Utils
 export { isEqual } from "./utils/is-equal";

--- a/test/crypto.test.ts
+++ b/test/crypto.test.ts
@@ -11,23 +11,14 @@ const impls = {
   // distJs: cryptoDistJS,
 };
 
-describe("crypto", () => {
-  for (const [name, { sha256, sha256base64 }] of Object.entries(impls)) {
+describe("crypto:stringDigest", () => {
+  for (const [name, { stringDigest }] of Object.entries(impls)) {
     describe(name, () => {
-      it("sha256", () => {
-        expect(sha256("Hello World")).toBe(
-          "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e",
-        );
-        expect(sha256("")).toBe(
-          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        );
-      });
-
-      it("sha256base64", () => {
-        expect(sha256base64("Hello World")).toBe(
+      it("stringDigest", () => {
+        expect(stringDigest("Hello World")).toBe(
           "pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4",
         );
-        expect(sha256base64("")).toBe(
+        expect(stringDigest("")).toBe(
           "47DEQpj8HBSaTImW5JCeuQeRkm5NMpJWZG3hSuFU",
         );
       });


### PR DESCRIPTION
Rename `sha256`/`sha256base64` into `stringDigest` with better description about algorithm.

Previous naming was confusing as digest is not exactly sha256+base64 (we trim `+/=` chars)

closes #85