### PR TITLE
refactor!: rename `objectHash` to `serialize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ deno install ohash
 
 ```js
 // ESM import
-import { hash, objectHash, isEqual, diff, stringDigest } from "ohash";
+import { hash, serialize, isEqual, diff, stringDigest } from "ohash";
 
 // ..or dnamic import
-const { hash, objectHash, stringDigest } = await import("ohash");
+const { hash, serialize, stringDigest } = await import("ohash");
 ```
 
 ### `hash(object, options?)`
@@ -64,26 +64,26 @@ console.log(hash({ foo: "bar" }));
 
 **How it works:**
 
-- Input will be serialized into a string like `"object:1:string:3:foo:string:3:bar,"`
-- Then it is hashed using [SHA-256](https://en.wikipedia.org/wiki/SHA-2) algorithm and encoded as a [base64](https://en.wikipedia.org/wiki/Base64) string
-- `+`, `/` and `=` characters will be removed and string trimmed to `10` chars
+- Input will be serialized into a string like `object:1:string:3:foo:string:3:bar,`.
+- Then it is hashed using [SHA-256](https://en.wikipedia.org/wiki/SHA-2) algorithm and encoded as a [base64](https://en.wikipedia.org/wiki/Base64) string.
+- `+`, `/` and `=` characters will be removed and string trimmed to `10` chars.
 
-### `objectHash(object, options?)`
+### `serialize(object, options?)`
 
 Serializes any value into a stable and safe string for hashing.
 
 **Usage:**
 
 ```js
-import { objectHash } from "ohash";
+import { serialize } from "ohash";
 
 // "object:1:string:3:foo:string:3:bar,"
-console.log(objectHash({ foo: "bar" }));
+console.log(serialize({ foo: "bar" }));
 ```
 
 ### `isEqual(obj1, obj2, options?)`
 
-Compare two objects using reference equality and stable object hashing.
+Compare two objects using `==` then fallbacks to compare using `serialize`.
 
 Usage:
 

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,4 +1,4 @@
-import { objectHash, type HashOptions } from "./object-hash";
+import { serialize, type SerializeOptions } from "./serialize";
 import { stringDigest } from "ohash/crypto";
 
 /**
@@ -10,11 +10,11 @@ import { stringDigest } from "ohash/crypto";
  * - `+`, `/` and `=` characters will be removed and string trimmed to `10` chars
  *
  * @param {object} object value to hash
- * @param {HashOptions} options hashing options. See {@link HashOptions}.
+ * @param {SerializeOptions} options hashing options. See {@link SerializeOptions}.
  * @return {string} hash value
  */
-export function hash(object: any, options: HashOptions = {}): string {
+export function hash(object: any, options: SerializeOptions = {}): string {
   const hashed =
-    typeof object === "string" ? object : objectHash(object, options);
+    typeof object === "string" ? object : serialize(object, options);
   return stringDigest(hashed).slice(0, 10);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Hash
-export { objectHash } from "./hash/object-hash";
-export { hash } from "./hash/hash";
+export { serialize, type SerializeOptions } from "./serialize";
+export { hash } from "./hash";
 
 // Crypto
 export { stringDigest } from "ohash/crypto";

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,6 +1,6 @@
 // Based on https://github.com/puleos/object-hash v3.0.0 (MIT)
 
-export interface HashOptions {
+export interface SerializeOptions {
   /**
    * Function to determine if a key should be excluded from hashing.
    * @optional
@@ -74,7 +74,7 @@ export interface HashOptions {
 }
 
 // Defaults
-const defaults: HashOptions = Object.freeze({
+const defaults: SerializeOptions = Object.freeze({
   ignoreUnknown: false,
   respectType: false,
   respectFunctionNames: false,
@@ -94,7 +94,7 @@ const defaults: HashOptions = Object.freeze({
  * @return {string} serialized value
  * @api public
  */
-export function objectHash(object: any, options?: HashOptions): string {
+export function serialize(object: any, options?: SerializeOptions): string {
   if (options) {
     options = { ...defaults, ...options };
   } else {
@@ -111,7 +111,7 @@ const defaultPrototypesKeys = Object.freeze([
   "constructor",
 ]);
 
-function createHasher(options: HashOptions) {
+function createHasher(options: SerializeOptions) {
   let buff = "";
   let context = new Map();
   const write = (str: string) => {

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,4 +1,4 @@
-import { objectHash, type HashOptions } from "../hash/object-hash";
+import { serialize, type SerializeOptions } from "../serialize";
 
 /**
  * Calculates the difference between two objects and returns a list of differences.
@@ -11,7 +11,7 @@ import { objectHash, type HashOptions } from "../hash/object-hash";
 export function diff(
   obj1: any,
   obj2: any,
-  opts: HashOptions = {},
+  opts: SerializeOptions = {},
 ): DiffEntry[] {
   const h1 = _toHashedObject(obj1, opts);
   const h2 = _toHashedObject(obj2, opts);
@@ -21,7 +21,7 @@ export function diff(
 function _diff(
   h1: DiffHashedObject,
   h2: DiffHashedObject,
-  opts: HashOptions = {},
+  opts: SerializeOptions = {},
 ): DiffEntry[] {
   const diffs = [];
 
@@ -52,11 +52,11 @@ function _diff(
 
 function _toHashedObject(
   obj: any,
-  opts: HashOptions,
+  opts: SerializeOptions,
   key = "",
 ): DiffHashedObject {
   if (obj && typeof obj !== "object") {
-    return new DiffHashedObject(key, obj, objectHash(obj, opts));
+    return new DiffHashedObject(key, obj, serialize(obj, opts));
   }
   const props: Record<string, DiffHashedObject> = {};
   const hashes = [];

--- a/src/utils/is-equal.ts
+++ b/src/utils/is-equal.ts
@@ -1,21 +1,21 @@
-import { objectHash, type HashOptions } from "../hash/object-hash";
+import { serialize, type SerializeOptions } from "../serialize";
 /**
  * Compare two objects using reference equality and stable deep hashing.
  * @param {any} object1 First object
  * @param {any} object2 Second object
- * @param {HashOptions} hashOptions. Configuration options for hashing the objects. See {@link HashOptions}.
+ * @param {SerializeOptions} SerializeOptions. Configuration options for hashing the objects. See {@link SerializeOptions}.
  * @return {boolean} true if equal and false if not
  * @api public
  */
 export function isEqual(
   object1: any,
   object2: any,
-  hashOptions: HashOptions = {},
+  hashOptions: SerializeOptions = {},
 ): boolean {
   if (object1 === object2) {
     return true;
   }
-  if (objectHash(object1, hashOptions) === objectHash(object2, hashOptions)) {
+  if (serialize(object1, hashOptions) === serialize(object2, hashOptions)) {
     return true;
   }
   return false;

--- a/test/ohash.test.ts
+++ b/test/ohash.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { objectHash, hash } from "../src";
+import { serialize, hash } from "../src";
 
 describe("hash", () => {
   it("hash", () => {
@@ -7,10 +7,10 @@ describe("hash", () => {
   });
 });
 
-describe("objectHash", () => {
+describe("serialize", () => {
   it("basic object", () => {
     expect(
-      objectHash({ foo: "bar", bar: new Date(0), bool: false }),
+      serialize({ foo: "bar", bar: new Date(0), bool: false }),
     ).toMatchInlineSnapshot(
       '"object:3:string:3:bar:string:24:1970-01-01T00:00:00.000Z,string:4:bool:bool:false,string:3:foo:string:3:bar,"',
     );
@@ -21,7 +21,7 @@ describe("objectHash", () => {
     form.set("foo", "bar");
     form.set("bar", "baz");
 
-    expect(objectHash(form)).toMatchInlineSnapshot(
+    expect(serialize(form)).toMatchInlineSnapshot(
       '"formdata:array:2:array:2:string:32:array:2:string:3:barstring:3:bazstring:32:array:2:string:3:foostring:3:bar"',
     );
   });
@@ -33,7 +33,7 @@ describe("objectHash", () => {
       }
     }
 
-    expect(objectHash(new Test())).toMatchInlineSnapshot(
+    expect(serialize(new Test())).toMatchInlineSnapshot(
       '"object:2:string:3:bar:string:3:baz,string:3:foo:string:3:bar,"',
     );
   });


### PR DESCRIPTION
This PR renames `objectHash` to `serialize` which is closer to what it does (although serialization is not two way fully) -- also reduces confusion between `hash` <> [serialize util] 