### PR TITLE
fix(hash, serialize): always serialize string inputs 

### DIFF
--- a/src/hash.ts
+++ b/src/hash.ts
@@ -14,7 +14,5 @@ import { stringDigest } from "ohash/crypto";
  * @return {string} hash value
  */
 export function hash(object: any, options: SerializeOptions = {}): string {
-  const hashed =
-    typeof object === "string" ? object : serialize(object, options);
-  return stringDigest(hashed).slice(0, 10);
+  return stringDigest(serialize(object, options)).slice(0, 10);
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -89,12 +89,16 @@ const defaults: SerializeOptions = Object.freeze({
 
 /**
  * Serialize any JS value into a stable, hashable string
+ *
  * @param {object} object value to hash
- * @param {HashOptions} options hashing options. See {@link HashOptions}.
+ * @param {SerializeOptions} options hashing options. See {@link SerializeOptions}.
  * @return {string} serialized value
  * @api public
  */
 export function serialize(object: any, options?: SerializeOptions): string {
+  if (typeof object === "string" && !options) {
+    return `string:${object.length}:${object}`;
+  }
   if (options) {
     options = { ...defaults, ...options };
   } else {

--- a/test/hash.test.ts
+++ b/test/hash.test.ts
@@ -5,4 +5,10 @@ describe("hash", () => {
   it("hash", () => {
     expect(hash({ foo: "bar" })).toMatchInlineSnapshot('"dZbtA7f0lK"');
   });
+
+  it("hash", () => {
+    expect(hash("object:1:string:3:foo:string:3:bar,")).toMatchInlineSnapshot(
+      `"I6W3uN12LB"`,
+    );
+  });
 });

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from "vitest";
 import { serialize } from "../src";
 
 describe("serialize", () => {
+  it("string", () => {
+    expect(serialize("hello world 😎")).toMatchInlineSnapshot(
+      `"string:14:hello world 😎"`,
+    );
+  });
+
   it("basic object", () => {
     expect(
       serialize({ foo: "bar", bar: new Date(0), bool: false }),


### PR DESCRIPTION
This PR updates `hash` to always use `serialize` even for `string` inputs + adds a fast path for string serialization.

This avoids possibly conflicting hashes with the object and their serialized string as input. (to be backported for v1)