### PR TITLE
fix(hash, serialize)!: always serialize string inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,14 @@ const { hash } = await import("https://esm.sh/ohash");
 
 Hashes any JS value into a string.
 
+The input is first [serialized](#serializeinput-options) into a string like `object:1:string:3:foo:string:3:bar,`, then it is [hashed](#digeststr) and truncated to a length of `10`.
+
 ```js
 import { hash } from "ohash";
 
 // "dZbtA7f0lK"
 console.log(hash({ foo: "bar" }));
 ```
-
-**How it works:**
-
-- If the input is not a string, it will be serialized into a string like `object:1:string:3:foo:string:3:bar,` using [`serialize()`](#serializeinput-options).
-- Then it is hashed using [SHA-256](https://en.wikipedia.org/wiki/SHA-2) algorithm and encoded as a [Base64](https://en.wikipedia.org/wiki/Base64) string using [`digest()`](#digeststr).
 
 ## `serialize(input, options?)`
 

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -4,17 +4,10 @@ import { digest } from "ohash/crypto";
 /**
  * Hashes any JS value into a string.
  *
- * **How it works:**
- * - Input will be serialized into a string like `"object:1:string:3:foo:string:3:bar,"`
- * - Then it is hashed using [SHA-256](https://en.wikipedia.org/wiki/SHA-2) algorithm and encoded as a [base64](https://en.wikipedia.org/wiki/Base64) string
- * - `+`, `/` and `=` characters will be removed and string trimmed to `10` chars
- *
  * @param {object} object value to hash
  * @param {SerializeOptions} options hashing options. See {@link SerializeOptions}.
  * @return {string} hash value
  */
 export function hash(object: any, options: SerializeOptions = {}): string {
-  const hashed =
-    typeof object === "string" ? object : serialize(object, options);
-  return digest(hashed).slice(0, 10);
+  return digest(serialize(object, options)).slice(0, 10);
 }

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -4,6 +4,8 @@ import { digest } from "ohash/crypto";
 /**
  * Hashes any JS value into a string.
  *
+ * The input is first serialized into a string like `object:1:string:3:foo:string:3:bar,`. It is then hashed and truncated to a length of `10`.
+ *
  * @param {object} object value to hash
  * @param {SerializeOptions} options hashing options. See {@link SerializeOptions}.
  * @return {string} hash value

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -89,12 +89,16 @@ const defaults: SerializeOptions = Object.freeze({
 
 /**
  * Serialize any JS value into a stable, hashable string
+ *
  * @param {object} object value to hash
- * @param {HashOptions} options hashing options. See {@link HashOptions}.
+ * @param {SerializeOptions} options hashing options. See {@link SerializeOptions}.
  * @return {string} serialized value
  * @api public
  */
 export function serialize(object: any, options?: SerializeOptions): string {
+  if (typeof object === "string" && !options) {
+    return `string:${object.length}:${object}`;
+  }
   if (options) {
     options = { ...defaults, ...options };
   } else {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -22,7 +22,7 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(4400); // <4.4kb
+    expect(bytes).toBeLessThanOrEqual(4500); // <4.5kb
     expect(gzipSize).toBeLessThanOrEqual(1600); // <1.6kb
   });
 });

--- a/test/hash.test.ts
+++ b/test/hash.test.ts
@@ -5,4 +5,10 @@ describe("hash", () => {
   it("hash", () => {
     expect(hash({ foo: "bar" })).toMatchInlineSnapshot('"dZbtA7f0lK"');
   });
+
+  it("hash", () => {
+    expect(hash("object:1:string:3:foo:string:3:bar,")).toMatchInlineSnapshot(
+      `"I6W3uN12LB"`,
+    );
+  });
 });

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from "vitest";
 import { serialize } from "../src";
 
 describe("serialize", () => {
+  it("string", () => {
+    expect(serialize("hello world 😎")).toMatchInlineSnapshot(
+      `"string:14:hello world 😎"`,
+    );
+  });
+
   it("basic object", () => {
     expect(
       serialize({ foo: "bar", bar: new Date(0), bool: false }),


### PR DESCRIPTION
(rework #108)

before this PR `hash(input)` does serialize objects into a string before applying digest. If the same serialized string is passed to hash, the result will be the same, leading to potential unwanted collisions. 

This PR makes sure we always use the same serialization algorithm to avoid this. Performance overhead will be minimal with added fast-path for string inputs to `serialize`

BREAKING CHANGE: `hash(string)` will be different than before. As a replacement for backward compatible behavior, `digest(string).slice(0, 100)` can be used.