### PR TITLE
refactor!: use standard base64url for `digest`

### DIFF
--- a/src/crypto/js/index.ts
+++ b/src/crypto/js/index.ts
@@ -22,7 +22,7 @@ const K = [
 ];
 
 const base64KeyStr =
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
 // Reusable object
 const W: number[] = [];

--- a/src/crypto/node/index.ts
+++ b/src/crypto/node/index.ts
@@ -7,8 +7,5 @@ import { createHash } from "node:crypto";
  * This behavior differs from standard SHA-256 + Base64 encoding.
  */
 export function digest(date: string): string {
-  return createHash("sha256")
-    .update(date)
-    .digest("base64")
-    .replace(/[+/=]/g, "");
+  return createHash("sha256").update(date).digest("base64url");
 }

--- a/test/crypto.test.ts
+++ b/test/crypto.test.ts
@@ -18,7 +18,7 @@ describe("crypto:digest", () => {
         expect(digest("Hello World")).toBe(
           "pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4",
         );
-        expect(digest("")).toBe("47DEQpj8HBSaTImW5JCeuQeRkm5NMpJWZG3hSuFU");
+        expect(digest("")).toBe("47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU");
       });
     });
   }


### PR DESCRIPTION
fully resolves #85

having some chars from base64 removed, increases chances of sha256 collisions. this PR changes `digest` (used by `hash`) to use standard base64 URL encoding.