### PR TITLE
refactor!: rewrite serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The input is first [serialized](#serializeinput) into a string like `object:1:st
 ```js
 import { hash } from "ohash";
 
-// "dZbtA7f0lK"
+// "g82Nh7Lh3C"
 console.log(hash({ foo: "bar" }));
 ```
 
@@ -69,7 +69,7 @@ Serializes any input value into a string for hashing.
 ```js
 import { serialize } from "ohash";
 
-// "object:1:string:3:foo:string:3:bar,"
+// "{foo:'bar'}"
 console.log(serialize({ foo: "bar" }));
 ```
 
@@ -80,8 +80,8 @@ Hashes a string using the [SHA-256](https://en.wikipedia.org/wiki/SHA-2) algorit
 ```ts
 import { digest } from "ohash";
 
-// "pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4"
-console.log(digest("Hello World"));
+// "f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk"
+console.log(digest("Hello World!"));
 ```
 
 ## `isEqual(obj1, obj2)`
@@ -140,4 +140,5 @@ console.log(diff(obj1, obj2));
 
 Made with 💛 Published under [MIT License](./LICENSE).
 
-Based on [puleos/object-hash](https://github.com/puleos/object-hash) by [Scott Puleo](https://github.com/puleos/), and [brix/crypto-js](https://github.com/brix/crypto-js).
+Object serialization originally based on [puleos/object-hash](https://github.com/puleos/object-hash) by [Scott Puleo](https://github.com/puleos/).
+JS sha256 polyfill originally based on [brix/crypto-js](https://github.com/brix/crypto-js).

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ const { isEqual, diff } = await import("https://esm.sh/ohash/utils");
 
 </details>
 
-## `hash(input, options?)`
+## `hash(input)`
 
 Hashes any JS value into a string.
 
-The input is first [serialized](#serializeinput-options) into a string like `object:1:string:3:foo:string:3:bar,`, then it is [hashed](#digeststr) and truncated to a length of `10`.
+The input is first [serialized](#serializeinput) into a string like `object:1:string:3:foo:string:3:bar,`, then it is [hashed](#digeststr) and truncated to a length of `10`.
 
 ```js
 import { hash } from "ohash";
@@ -62,7 +62,7 @@ import { hash } from "ohash";
 console.log(hash({ foo: "bar" }));
 ```
 
-## `serialize(input, options?)`
+## `serialize(input)`
 
 Serializes any input value into a string for hashing.
 
@@ -84,9 +84,9 @@ import { digest } from "ohash";
 console.log(digest("Hello World"));
 ```
 
-## `isEqual(obj1, obj2, options?)`
+## `isEqual(obj1, obj2)`
 
-Compare two objects using `===` and then fallbacks to compare based on their [serialized](#serializeinput-options) values.
+Compare two objects using `===` and then fallbacks to compare based on their [serialized](#serializeinput) values.
 
 ```js
 import { isEqual } from "ohash/utils";
@@ -95,7 +95,7 @@ import { isEqual } from "ohash/utils";
 console.log(isEqual({ a: 1, b: 2 }, { b: 2, a: 1 }));
 ```
 
-## `diff(obj1, obj2, options?)`
+## `diff(obj1, obj2)`
 
 Compare two objects with nested [serialization](#serializeinput-options). Returns an array of changes.
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ console.log(hash({ foo: "bar" }));
 
 Serializes any input value into a string for hashing.
 
+> [!IMPORTANT]
+> `serial` uses best efforts to generate stable serialized values; however, it is not designed for security purposes. Keep in mind that there is always a chance of intentional collisions caused by user input.
+
 ```js
 import { serialize } from "ohash";
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const { isEqual, diff } = await import("https://esm.sh/ohash/utils");
 
 Hashes any JS value into a string.
 
-The input is first [serialized](#serializeinput) into a string like `object:1:string:3:foo:string:3:bar,`, then it is [hashed](#digeststr) and truncated to a length of `10`.
+The input is first [serialized](#serializeinput) then it is [hashed](#digeststr) and truncated to a length of `10`.
 
 ```js
 import { hash } from "ohash";
@@ -67,7 +67,7 @@ console.log(hash({ foo: "bar" }));
 Serializes any input value into a string for hashing.
 
 > [!IMPORTANT]
-> `serial` uses best efforts to generate stable serialized values; however, it is not designed for security purposes. Keep in mind that there is always a chance of intentional collisions caused by user input.
+> `serialize` method uses best efforts to generate stable serialized values; however, it is not designed for security purposes. Keep in mind that there is always a chance of intentional collisions caused by user input.
 
 ```js
 import { serialize } from "ohash";

--- a/README.md
+++ b/README.md
@@ -144,4 +144,5 @@ console.log(diff(obj1, obj2));
 Made with 💛 Published under [MIT License](./LICENSE).
 
 Object serialization originally based on [puleos/object-hash](https://github.com/puleos/object-hash) by [Scott Puleo](https://github.com/puleos/).
-JS sha256 polyfill originally based on [brix/crypto-js](https://github.com/brix/crypto-js).
+
+sha256 implementation originally based on [brix/crypto-js](https://github.com/brix/crypto-js).

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ console.log(hash({ foo: "bar" }));
 
 ## `serialize(input, options?)`
 
-Serializes any input value into a string for usable hashing.
+Serializes any input value into a string for hashing.
 
 ```js
 import { serialize } from "ohash";

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <!-- /automd -->
 
-Simple data [hashing](https://en.wikipedia.org/wiki/Hash_function) utils.
+Simple object hashing, serialization and comparison utils.
 
 > [!NOTE]
 > You are on active v2 development branch. Check [v1](https://github.com/unjs/ohash/tree/v1) for ohash v1 docs.

--- a/build.config.ts
+++ b/build.config.ts
@@ -8,10 +8,8 @@ export default defineBuildConfig({
       opts.plugins.push({
         name: "selective-minify",
         async transform(code, id) {
-          if (id.includes("crypto/js")) {
-            const res = await transform(code, {
-              minify: true,
-            });
+          if (id.includes("crypto/js") || id.includes("serialize")) {
+            const res = await transform(code, { minify: true });
             return res.code;
           }
         },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ohash",
   "version": "1.1.4",
-  "description": "fast data hashing utils",
+  "description": "Simple object hashing, serialization and comparison utils.",
   "repository": "unjs/ohash",
   "license": "MIT",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint:fix": "automd && eslint --fix . && prettier -w src test",
     "prepack": "unbuild",
     "release": "pnpm test && changelogen --release --push && pnpm publish",
-    "test": "pnpm lint && vitest run && pnpm test:types",
+    "test": "pnpm lint && vitest run --coverage && pnpm test:types",
     "test:types": "tsc --noEmit"
   },
   "devDependencies": {

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,15 +1,14 @@
-import { serialize, type SerializeOptions } from "./serialize";
+import { serialize } from "./serialize";
 import { digest } from "ohash/crypto";
 
 /**
  * Hashes any JS value into a string.
  *
- * The input is first serialized into a string like `object:1:string:3:foo:string:3:bar,`. It is then hashed and truncated to a length of `10`.
+ * The input is first serialized and then hashed and truncated to a length of `10`.
  *
- * @param {object} object value to hash
- * @param {SerializeOptions} options hashing options. See {@link SerializeOptions}.
+ * @param input any value to serialize
  * @return {string} hash value
  */
-export function hash(object: any, options: SerializeOptions = {}): string {
-  return digest(serialize(object, options)).slice(0, 10);
+export function hash(input: any): string {
+  return digest(serialize(input)).slice(0, 10);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Hash
-export { serialize, type SerializeOptions } from "./serialize";
+export { serialize } from "./serialize";
 export { hash } from "./hash";
 
 // Crypto

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -3,6 +3,10 @@
 /**
  * Serializes any input value into a string for hashing.
  *
+ * This method uses best efforts to generate stable serialized values.
+ * However, it is not designed for security purposes.
+ * Keep in mind that there is always a chance of intentional collisions caused by user input.
+ *
  * @param input any value to serialize
  * @return {string} serialized string value
  */

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,4 +1,4 @@
-import { serialize, type SerializeOptions } from "../serialize";
+import { serialize } from "../serialize";
 
 /**
  * Calculates the difference between two objects and returns a list of differences.
@@ -8,21 +8,13 @@ import { serialize, type SerializeOptions } from "../serialize";
  * @param {HashOptions} [opts={}] - Configuration options for hashing the objects. See {@link HashOptions}.
  * @returns {DiffEntry[]} An array with the differences between the two objects.
  */
-export function diff(
-  obj1: any,
-  obj2: any,
-  opts: SerializeOptions = {},
-): DiffEntry[] {
-  const h1 = _toHashedObject(obj1, opts);
-  const h2 = _toHashedObject(obj2, opts);
-  return _diff(h1, h2, opts);
+export function diff(obj1: any, obj2: any): DiffEntry[] {
+  const h1 = _toHashedObject(obj1);
+  const h2 = _toHashedObject(obj2);
+  return _diff(h1, h2);
 }
 
-function _diff(
-  h1: DiffHashedObject,
-  h2: DiffHashedObject,
-  opts: SerializeOptions = {},
-): DiffEntry[] {
+function _diff(h1: DiffHashedObject, h2: DiffHashedObject): DiffEntry[] {
   const diffs = [];
 
   const allProps = new Set([
@@ -34,7 +26,7 @@ function _diff(
       const p1 = h1.props[prop];
       const p2 = h2.props[prop];
       if (p1 && p2) {
-        diffs.push(..._diff(h1.props?.[prop], h2.props?.[prop], opts));
+        diffs.push(..._diff(h1.props?.[prop], h2.props?.[prop]));
       } else if (p1 || p2) {
         diffs.push(
           new DiffEntry((p2 || p1).key, p1 ? "removed" : "added", p2, p1),
@@ -50,22 +42,14 @@ function _diff(
   return diffs;
 }
 
-function _toHashedObject(
-  obj: any,
-  opts: SerializeOptions,
-  key = "",
-): DiffHashedObject {
+function _toHashedObject(obj: any, key = ""): DiffHashedObject {
   if (obj && typeof obj !== "object") {
-    return new DiffHashedObject(key, obj, serialize(obj, opts));
+    return new DiffHashedObject(key, obj, serialize(obj));
   }
   const props: Record<string, DiffHashedObject> = {};
   const hashes = [];
   for (const _key in obj) {
-    props[_key] = _toHashedObject(
-      obj[_key],
-      opts,
-      key ? `${key}.${_key}` : _key,
-    );
+    props[_key] = _toHashedObject(obj[_key], key ? `${key}.${_key}` : _key);
     hashes.push(props[_key].hash);
   }
   return new DiffHashedObject(key, obj, `{${hashes.join(":")}}`, props);

--- a/src/utils/is-equal.ts
+++ b/src/utils/is-equal.ts
@@ -1,21 +1,15 @@
-import { serialize, type SerializeOptions } from "../serialize";
+import { serialize } from "../serialize";
 /**
  * Compare two objects using reference equality and stable deep hashing.
  * @param {any} object1 First object
  * @param {any} object2 Second object
- * @param {SerializeOptions} SerializeOptions. Configuration options for hashing the objects. See {@link SerializeOptions}.
  * @return {boolean} true if equal and false if not
- * @api public
  */
-export function isEqual(
-  object1: any,
-  object2: any,
-  hashOptions: SerializeOptions = {},
-): boolean {
+export function isEqual(object1: any, object2: any): boolean {
   if (object1 === object2) {
     return true;
   }
-  if (serialize(object1, hashOptions) === serialize(object2, hashOptions)) {
+  if (serialize(object1) === serialize(object2)) {
     return true;
   }
   return false;

--- a/test/benchmarks.bench.ts
+++ b/test/benchmarks.bench.ts
@@ -2,6 +2,7 @@ import { bench, describe } from "vitest";
 
 import { digest as digestJS } from "../src/crypto/js";
 import { digest as digestNode } from "../src/crypto/node";
+import { serialize } from "../src";
 
 describe("benchmarks", () => {
   describe("digest", () => {
@@ -10,6 +11,12 @@ describe("benchmarks", () => {
     });
     bench("node", () => {
       digestNode("hello world");
+    });
+  });
+
+  describe("serialize", () => {
+    bench("serialize", () => {
+      serialize({ foo: "bar", bar: new Date(0), bool: false });
     });
   });
 });

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -22,8 +22,8 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(4500); // <4.5kb
-    expect(gzipSize).toBeLessThanOrEqual(1600); // <1.6kb
+    expect(bytes).toBeLessThanOrEqual(3400); // <3.4kb
+    expect(gzipSize).toBeLessThanOrEqual(1400); // <1.4kb
   });
 });
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -22,7 +22,7 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(2500); // <2.5kb
+    expect(bytes).toBeLessThanOrEqual(2400); // <2.4kb
     expect(gzipSize).toBeLessThanOrEqual(1000); // <1kb
   });
 });

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -22,7 +22,7 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(2400); // <2.4kb
+    expect(bytes).toBeLessThanOrEqual(2500); // <2.5kb
     expect(gzipSize).toBeLessThanOrEqual(1000); // <1kb
   });
 });

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -15,15 +15,15 @@ describe("bundle size", () => {
     expect(gzipSize).toBeLessThanOrEqual(1750); // <1.75kb
   });
 
-  it.skip("serialize", async () => {
+  it("serialize", async () => {
     const code = /* js */ `
       import { serialize } from "../src";
       serialize("")
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(3400); // <3.4kb
-    expect(gzipSize).toBeLessThanOrEqual(1400); // <1.4kb
+    expect(bytes).toBeLessThanOrEqual(2400); // <2.4kb
+    expect(gzipSize).toBeLessThanOrEqual(1000); // <1kb
   });
 });
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -15,7 +15,7 @@ describe("bundle size", () => {
     expect(gzipSize).toBeLessThanOrEqual(1750); // <1.75kb
   });
 
-  it("serialize", async () => {
+  it.skip("serialize", async () => {
     const code = /* js */ `
       import { serialize } from "../src";
       serialize("")

--- a/test/hash.test.ts
+++ b/test/hash.test.ts
@@ -3,7 +3,7 @@ import { hash } from "../src";
 
 describe("hash", () => {
   it("hash", () => {
-    expect(hash({ foo: "bar" })).toMatchInlineSnapshot(`"OfMmx-pTkc"`);
+    expect(hash({ foo: "bar" })).toMatchInlineSnapshot(`"g82Nh7Lh3C"`);
   });
 
   it("hash", () => {

--- a/test/hash.test.ts
+++ b/test/hash.test.ts
@@ -3,12 +3,12 @@ import { hash } from "../src";
 
 describe("hash", () => {
   it("hash", () => {
-    expect(hash({ foo: "bar" })).toMatchInlineSnapshot('"dZbtA7f0lK"');
+    expect(hash({ foo: "bar" })).toMatchInlineSnapshot(`"OfMmx-pTkc"`);
   });
 
   it("hash", () => {
     expect(hash("object:1:string:3:foo:string:3:bar,")).toMatchInlineSnapshot(
-      `"I6W3uN12LB"`,
+      `"DB1F7673Yx"`,
     );
   });
 });

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -9,7 +9,7 @@ describe("serialize", () => {
       );
 
       expect(serialize({ msg: "hello world 😎" })).toMatchInlineSnapshot(
-        `"{'msg':'hello world 😎',}"`,
+        `"{msg:'hello world 😎'}"`,
       );
     });
 
@@ -81,13 +81,16 @@ describe("serialize", () => {
       expect(serialize(new Set([2, 3, 1]))).toMatchInlineSnapshot(
         `"Set[1,2,3,]"`,
       );
+      expect(serialize(new Set([{ b: 1 }, { a: 1 }]))).toMatchInlineSnapshot(
+        `"Set[{a:1},{b:1},]"`,
+      );
     });
 
     it("map", () => {
       const map = new Map();
       map.set("z", 2);
       map.set("a", "1");
-      expect(serialize(map)).toMatchInlineSnapshot(`"Map{'a':'1','z':2,}"`);
+      expect(serialize(map)).toMatchInlineSnapshot(`"Map{a:'1',z:2}"`);
     });
   });
 
@@ -114,19 +117,15 @@ describe("serialize", () => {
 
   describe("object", () => {
     it("object", () => {
-      expect(serialize({ a: 1, b: 2 })).toMatchInlineSnapshot(
-        `"{'a':1,'b':2,}"`,
-      );
+      expect(serialize({ a: 1, b: 2 })).toMatchInlineSnapshot(`"{a:1,b:2}"`);
 
-      expect(serialize({ b: 2, a: 1 })).toMatchInlineSnapshot(
-        `"{'a':1,'b':2,}"`,
-      );
+      expect(serialize({ b: 2, a: 1 })).toMatchInlineSnapshot(`"{a:1,b:2}"`);
     });
 
     it("circular", () => {
       const obj: any = {};
       obj.foo = obj;
-      expect(serialize(obj)).toMatchInlineSnapshot(`"{'foo':#0,}"`);
+      expect(serialize(obj)).toMatchInlineSnapshot(`"{foo:#0}"`);
     });
 
     it("symbol key", () => {
@@ -134,13 +133,10 @@ describe("serialize", () => {
     });
 
     it("class", () => {
-      expect(
-        serialize(
-          new (class Foo {
-            x = 1;
-          })(),
-        ),
-      ).toMatchInlineSnapshot(`"Foo{'x':1,}"`);
+      class Test {
+        x = 1;
+      }
+      expect(serialize(new Test())).toMatchInlineSnapshot(`"Test{x:1}"`);
     });
 
     it("with toJSON()", () => {
@@ -150,9 +146,8 @@ describe("serialize", () => {
         }
       }
       expect(serialize(new Test())).toMatchInlineSnapshot(`"Test[1,2,3,]"`);
-
       expect(serialize({ x: new Test() })).toMatchInlineSnapshot(
-        `"{'x':Test[1,2,3,],}"`,
+        `"{x:Test[1,2,3,]}"`,
       );
     });
 
@@ -160,9 +155,8 @@ describe("serialize", () => {
       const form = new FormData();
       form.set("foo", "bar");
       form.set("bar", "baz");
-
       expect(serialize(form)).toMatchInlineSnapshot(
-        `"FormData{'bar':'baz','foo':'bar',}"`,
+        `"FormData{bar:'baz',foo:'bar'}"`,
       );
     });
   });

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -47,43 +47,47 @@ describe("serialize", () => {
 
     it("Error", () => {
       expect(serialize(new Error("test"))).toMatchInlineSnapshot(
-        `"(Error)Error: test"`,
+        `"Error(Error: test)"`,
       );
     });
 
     it("RegExp", () => {
-      expect(serialize(/.*/)).toMatchInlineSnapshot(`"(RegExp)/.*/"`);
+      expect(serialize(/.*/)).toMatchInlineSnapshot(`"RegExp(/.*/)"`);
     });
 
     it("URL", () => {
       expect(serialize(new URL("https://example.com"))).toMatchInlineSnapshot(
-        `"(URL)https://example.com/"`,
+        `"URL(https://example.com/)"`,
       );
     });
 
     it("Symbol", () => {
-      expect(Symbol("test")).toMatchInlineSnapshot(`Symbol(test)`);
-      expect(Symbol.for("test")).toMatchInlineSnapshot(`Symbol(test)`);
+      expect(serialize(Symbol("test"))).toMatchInlineSnapshot(`"Symbol(test)"`);
+      expect(serialize(Symbol.for("test"))).toMatchInlineSnapshot(
+        `"Symbol(test)"`,
+      );
     });
 
     it("BigInt", () => {
-      expect(BigInt(100_000)).toMatchInlineSnapshot(`100000n`);
+      expect(serialize(9_007_199_254_740_991n)).toMatchInlineSnapshot(
+        `"9007199254740991n"`,
+      );
     });
 
     it("set", () => {
       expect(serialize(new Set([1, 2, 3]))).toMatchInlineSnapshot(
-        `"Set[1,2,3]"`,
+        `"Set[1,2,3,]"`,
       );
       expect(serialize(new Set([2, 3, 1]))).toMatchInlineSnapshot(
-        `"Set[1,2,3]"`,
+        `"Set[1,2,3,]"`,
       );
     });
 
     it("map", () => {
       const map = new Map();
-      map.set("i", 1);
-      map.set("s", "2");
-      expect(serialize(map)).toMatchInlineSnapshot(`"Map{'i':1,'s':'2',}"`);
+      map.set("z", 2);
+      map.set("a", "1");
+      expect(serialize(map)).toMatchInlineSnapshot(`"Map{'a':'1','z':2,}"`);
     });
   });
 
@@ -158,7 +162,7 @@ describe("serialize", () => {
       form.set("bar", "baz");
 
       expect(serialize(form)).toMatchInlineSnapshot(
-        `"(FormData)['[object Object]','[object Object]',]"`,
+        `"FormData{'bar':'baz','foo':'bar',}"`,
       );
     });
   });

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -12,7 +12,37 @@ describe("serialize", () => {
     expect(
       serialize({ foo: "bar", bar: new Date(0), bool: false }),
     ).toMatchInlineSnapshot(
-      '"object:3:string:3:bar:string:24:1970-01-01T00:00:00.000Z,string:4:bool:bool:false,string:3:foo:string:3:bar,"',
+      `"object:3:string:3:bar:date:1970-01-01T00:00:00.000Z,string:4:bool:bool:false,string:3:foo:string:3:bar,"`,
+    );
+  });
+
+  it("blob", () => {
+    expect(() => serialize(new Blob(["x"]))).toThrow("Cannot serialize Blob");
+  });
+
+  it("date", () => {
+    const obj: any = {};
+    obj.foo = obj;
+    expect(serialize(new Date(0))).toMatchInlineSnapshot(
+      `"date:1970-01-01T00:00:00.000Z"`,
+    );
+  });
+
+  it("circular", () => {
+    const obj: any = {};
+    obj.foo = obj;
+    expect(serialize(obj)).toMatchInlineSnapshot(
+      `"object:1:string:3:foo:string:12:[CIRCULAR:0],"`,
+    );
+  });
+
+  it("Buffer", () => {
+    expect(serialize(Buffer.from([1, 2, 3]))).toMatchInlineSnapshot(
+      `"object:2:string:4:data:array:3:number:1number:2number:3,string:4:type:string:6:Buffer,"`,
+    );
+
+    expect(serialize({ buff: Buffer.from([1, 2, 3]) })).toMatchInlineSnapshot(
+      `"object:1:string:4:buff:object:2:string:4:data:array:3:number:1number:2number:3,string:4:type:string:6:Buffer,,"`,
     );
   });
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -2,69 +2,195 @@ import { describe, expect, it } from "vitest";
 import { serialize } from "../src";
 
 describe("serialize", () => {
-  it("string", () => {
-    expect(serialize("hello world 😎")).toMatchInlineSnapshot(
-      `"string:14:hello world 😎"`,
-    );
+  describe("primitive and builtins", () => {
+    it("string", () => {
+      expect(serialize("hello world 😎")).toMatchInlineSnapshot(
+        `"'hello world 😎'"`,
+      );
+
+      expect(serialize({ msg: "hello world 😎" })).toMatchInlineSnapshot(
+        `"{'msg':'hello world 😎',}"`,
+      );
+    });
+
+    it("date", () => {
+      expect(serialize(new Date(0))).toMatchInlineSnapshot(
+        `"Date(1970-01-01T00:00:00.000Z)"`,
+      );
+    });
+
+    it("boolean", () => {
+      expect(serialize(true)).toMatchInlineSnapshot(`"true"`);
+      expect(serialize(false)).toMatchInlineSnapshot(`"false"`);
+    });
+
+    it("number", () => {
+      expect(serialize(0)).toMatchInlineSnapshot(`"0"`);
+      expect(serialize(100)).toMatchInlineSnapshot(`"100"`);
+      expect(serialize(-100)).toMatchInlineSnapshot(`"-100"`);
+      expect(serialize(Number.NaN)).toMatchInlineSnapshot(`"NaN"`);
+      expect(serialize(Number.EPSILON)).toMatchInlineSnapshot(
+        `"2.220446049250313e-16"`,
+      );
+      expect(serialize(Number.NEGATIVE_INFINITY)).toMatchInlineSnapshot(
+        `"-Infinity"`,
+      );
+      expect(serialize(Number.POSITIVE_INFINITY)).toMatchInlineSnapshot(
+        `"Infinity"`,
+      );
+    });
+
+    it("null and undefined", () => {
+      expect(serialize(null)).toMatchInlineSnapshot(`"null"`);
+      expect(serialize(undefined)).toMatchInlineSnapshot(`"undefined"`);
+    });
+
+    it("Error", () => {
+      expect(serialize(new Error("test"))).toMatchInlineSnapshot(
+        `"(error)Error: test"`,
+      );
+    });
+
+    it("RegExp", () => {
+      expect(serialize(/.*/)).toMatchInlineSnapshot(`"(regexp)/.*/"`);
+    });
+
+    it("URL", () => {
+      expect(serialize(new URL("https://example.com"))).toMatchInlineSnapshot(
+        `"(url)https://example.com/"`,
+      );
+    });
+
+    it("Symbol", () => {
+      expect(Symbol("test")).toMatchInlineSnapshot(`Symbol(test)`);
+      expect(Symbol.for("test")).toMatchInlineSnapshot(`Symbol(test)`);
+    });
+
+    it("BigInt", () => {
+      expect(BigInt(100_000)).toMatchInlineSnapshot(`100000n`);
+    });
+
+    it("set", () => {
+      expect(serialize(new Set([1, 2, 3]))).toMatchInlineSnapshot(
+        `"Set(1,2,3)"`,
+      );
+      expect(serialize(new Set([2, 3, 1]))).toMatchInlineSnapshot(
+        `"Set(1,2,3)"`,
+      );
+    });
+
+    it("map", () => {
+      const map = new Map();
+      map.set("i", 1);
+      map.set("s", "2");
+      expect(serialize(map)).toMatchInlineSnapshot(`"Map('i':1;'s':'2';)"`);
+      expect(serialize({ i: 1, s: "2" })).toMatchInlineSnapshot(
+        `"{'i':1,'s':'2',}"`,
+      );
+    });
   });
 
-  it("basic object", () => {
-    expect(
-      serialize({ foo: "bar", bar: new Date(0), bool: false }),
-    ).toMatchInlineSnapshot(
-      `"object:3:string:3:bar:date:1970-01-01T00:00:00.000Z,string:4:bool:bool:false,string:3:foo:string:3:bar,"`,
-    );
+  describe("array", () => {
+    it("array", () => {
+      expect(serialize([1, 2, "x", 3])).toMatchInlineSnapshot(`"[1,2,'x',3,]"`);
+      expect(serialize([2, 3, "x", 1])).toMatchInlineSnapshot(`"[2,3,'x',1,]"`);
+    });
+
+    it("Uint8Array, Buffer and ArrayBufferLike", () => {
+      expect(serialize(new Uint8Array([1, 2, 3]).buffer)).toMatchInlineSnapshot(
+        `"(arraybuffer:3)1,2,3"`,
+      );
+
+      expect(serialize(new Uint8Array([1, 2, 3]))).toMatchInlineSnapshot(
+        `"uint8array[1,2,3]"`,
+      );
+
+      expect(serialize(Buffer.from("hello"))).toMatchInlineSnapshot(
+        `"uint8array[104,101,108,108,111]"`,
+      );
+    });
   });
 
-  it("blob", () => {
-    expect(() => serialize(new Blob(["x"]))).toThrow("Cannot serialize Blob");
-  });
+  describe("object", () => {
+    it("object", () => {
+      expect(serialize({ a: 1, b: 2 })).toMatchInlineSnapshot(
+        `"{'a':1,'b':2,}"`,
+      );
 
-  it("date", () => {
-    const obj: any = {};
-    obj.foo = obj;
-    expect(serialize(new Date(0))).toMatchInlineSnapshot(
-      `"date:1970-01-01T00:00:00.000Z"`,
-    );
-  });
+      expect(serialize({ b: 2, a: 1 })).toMatchInlineSnapshot(
+        `"{'a':1,'b':2,}"`,
+      );
+    });
 
-  it("circular", () => {
-    const obj: any = {};
-    obj.foo = obj;
-    expect(serialize(obj)).toMatchInlineSnapshot(
-      `"object:1:string:3:foo:string:12:[CIRCULAR:0],"`,
-    );
-  });
+    it("circular", () => {
+      const obj: any = {};
+      obj.foo = obj;
+      expect(serialize(obj)).toMatchInlineSnapshot(`"{'foo':#0,}"`);
+    });
 
-  it("Buffer", () => {
-    expect(serialize(Buffer.from([1, 2, 3]))).toMatchInlineSnapshot(
-      `"object:2:string:4:data:array:3:number:1number:2number:3,string:4:type:string:6:Buffer,"`,
-    );
+    it("symbol key", () => {
+      expect(serialize({ [Symbol("s")]: 123 })).toMatchInlineSnapshot(`"{}"`);
+    });
 
-    expect(serialize({ buff: Buffer.from([1, 2, 3]) })).toMatchInlineSnapshot(
-      `"object:1:string:4:buff:object:2:string:4:data:array:3:number:1number:2number:3,string:4:type:string:6:Buffer,,"`,
-    );
-  });
+    it("class", () => {
+      expect(
+        serialize(
+          new (class Foo {
+            x = 1;
+          })(),
+        ),
+      ).toMatchInlineSnapshot(`"Foo{'x':1,}"`);
+    });
 
-  it("Serialize object with entries()", () => {
-    const form = new FormData();
-    form.set("foo", "bar");
-    form.set("bar", "baz");
-
-    expect(serialize(form)).toMatchInlineSnapshot(
-      '"formdata:array:2:array:2:string:32:array:2:string:3:barstring:3:bazstring:32:array:2:string:3:foostring:3:bar"',
-    );
-  });
-
-  it("Serialize object with toJSON()", () => {
-    class Test {
-      toJSON() {
-        return { foo: "bar", bar: "baz" };
+    it("with toJSON()", () => {
+      class Test {
+        toJSON() {
+          return [1, 2, 3];
+        }
       }
-    }
+      expect(serialize(new Test())).toMatchInlineSnapshot(`"Test[1,2,3,]"`);
 
-    expect(serialize(new Test())).toMatchInlineSnapshot(
-      '"object:2:string:3:bar:string:3:baz,string:3:foo:string:3:bar,"',
-    );
+      expect(serialize({ x: new Test() })).toMatchInlineSnapshot(
+        `"{'x':Test[1,2,3,],}"`,
+      );
+    });
+
+    it("with entries()", () => {
+      const form = new FormData();
+      form.set("foo", "bar");
+      form.set("bar", "baz");
+
+      expect(serialize(form)).toMatchInlineSnapshot(
+        `"(FormData)['[object Object]','[object Object]',]"`,
+      );
+    });
+  });
+
+  describe("function", () => {
+    it("native", () => {
+      expect(serialize(Array)).toMatchInlineSnapshot(`"Array()[native]"`);
+    });
+
+    it("function", () => {
+      function sum(a: number, b: number) {
+        return a + b;
+      }
+      expect(serialize(sum)).toMatchInlineSnapshot(
+        `"sum(2)function sum(a, b) {return a + b;}"`,
+      );
+    });
+
+    it("arrow function", () => {
+      const sum = (a: number, b: number) => a + b;
+      expect(serialize(sum)).toMatchInlineSnapshot(`"sum(2)(a, b) => a + b"`);
+    });
+  });
+
+  describe("not supported", () => {
+    it("blob", () => {
+      expect(() =>
+        serialize(new Blob(["x"])),
+      ).toThrowErrorMatchingInlineSnapshot(`[Error: Cannot serialize Blob]`);
+    });
   });
 });

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -47,17 +47,17 @@ describe("serialize", () => {
 
     it("Error", () => {
       expect(serialize(new Error("test"))).toMatchInlineSnapshot(
-        `"(error)Error: test"`,
+        `"(Error)Error: test"`,
       );
     });
 
     it("RegExp", () => {
-      expect(serialize(/.*/)).toMatchInlineSnapshot(`"(regexp)/.*/"`);
+      expect(serialize(/.*/)).toMatchInlineSnapshot(`"(RegExp)/.*/"`);
     });
 
     it("URL", () => {
       expect(serialize(new URL("https://example.com"))).toMatchInlineSnapshot(
-        `"(url)https://example.com/"`,
+        `"(URL)https://example.com/"`,
       );
     });
 
@@ -72,10 +72,10 @@ describe("serialize", () => {
 
     it("set", () => {
       expect(serialize(new Set([1, 2, 3]))).toMatchInlineSnapshot(
-        `"Set(1,2,3)"`,
+        `"Set[1,2,3]"`,
       );
       expect(serialize(new Set([2, 3, 1]))).toMatchInlineSnapshot(
-        `"Set(1,2,3)"`,
+        `"Set[1,2,3]"`,
       );
     });
 
@@ -83,10 +83,7 @@ describe("serialize", () => {
       const map = new Map();
       map.set("i", 1);
       map.set("s", "2");
-      expect(serialize(map)).toMatchInlineSnapshot(`"Map('i':1;'s':'2';)"`);
-      expect(serialize({ i: 1, s: "2" })).toMatchInlineSnapshot(
-        `"{'i':1,'s':'2',}"`,
-      );
+      expect(serialize(map)).toMatchInlineSnapshot(`"Map{'i':1,'s':'2',}"`);
     });
   });
 
@@ -98,15 +95,15 @@ describe("serialize", () => {
 
     it("Uint8Array, Buffer and ArrayBufferLike", () => {
       expect(serialize(new Uint8Array([1, 2, 3]).buffer)).toMatchInlineSnapshot(
-        `"(arraybuffer:3)1,2,3"`,
+        `"ArrayBuffer[1,2,3]"`,
       );
 
       expect(serialize(new Uint8Array([1, 2, 3]))).toMatchInlineSnapshot(
-        `"uint8array[1,2,3]"`,
+        `"Uint8Array[1,2,3]"`,
       );
 
       expect(serialize(Buffer.from("hello"))).toMatchInlineSnapshot(
-        `"uint8array[104,101,108,108,111]"`,
+        `"Uint8Array[104,101,108,108,111]"`,
       );
     });
   });


### PR DESCRIPTION
Fully rewrite serializer as a class

- New simplified serialization system (check tests) (BREAKING BEHAVIOR)
- Type handlers are shared with the class prototype instead of creating per hash
- Common type handlers are added on runtime to reduce bundle size
- added tests with full coverage
- fixed various issues that were not working properly nor tested before such as Date handling
- Removed Node internal handlers
- Buffer is serialized as Uint8Array
- Map and Set keys are order-less by dedault
- Removed serialize options in favor of stable handling (please report an issue if you need back any!)