### PR TITLE
perf: use node crypto `hash` when available

### DIFF
--- a/src/crypto/node/index.ts
+++ b/src/crypto/node/index.ts
@@ -9,6 +9,8 @@ import { createHash, hash } from "node:crypto";
  */
 export function digest(data: string): string {
   if (hash) {
+    // Available in Node.js v21.7.0+, v20.12.0+
+    // https://nodejs.org/api/crypto.html#cryptohashalgorithm-data-outputencoding
     return hash("sha256", data, "base64url");
   }
   return createHash("sha256").update(data).digest("base64url");


### PR DESCRIPTION
Use faster one-shot [`hash()`](https://nodejs.org/api/crypto.html#cryptohashalgorithm-data-outputencoding) from `node:crypto` when available (added in Node.js v21.7.0, v20.12.0)

Benchmark speedup from (rps) 717,953 => 1,021,298 on my PC

Thanks for great suggestion from @aquapi in e18e discord group. benchmarks from [here](https://github.com/re-utils/fast-crypt/tree/main/bench/others/sha256)