### PR TITLE
fix: workaround for stackblitz

### DIFF
--- a/src/crypto/node/index.ts
+++ b/src/crypto/node/index.ts
@@ -13,5 +13,7 @@ export function digest(data: string): string {
     // https://nodejs.org/api/crypto.html#cryptohashalgorithm-data-outputencoding
     return hash("sha256", data, "base64url");
   }
-  return createHash("sha256").update(data).digest("base64url");
+  // Use digest().toString("base64url") as workaround for stackblitz
+  // https://github.com/unjs/ohash/issues/115
+  return createHash("sha256").update(data).digest().toString("base64url");
 }


### PR DESCRIPTION
resolves #115

Workaround for stackblitz as `digest('base64url')` does not works but `digest(): Buffer` chained with `.toString('base64url')` does work.

On slow paths (Node.js 18, <21.7, <20.12) (see #116), it has downgrades performance from 728,011 rps to 533,944