### PR TITLE
fix: use `process.getBuiltinModule` to import fast hash

### DIFF
--- a/src/crypto/node/index.ts
+++ b/src/crypto/node/index.ts
@@ -1,4 +1,9 @@
-import { createHash, hash } from "node:crypto";
+import { createHash } from "node:crypto";
+
+// Available in Node.js v21.7.0+, v20.12.0+
+// https://nodejs.org/api/crypto.html#cryptohashalgorithm-data-outputencoding
+const fastHash = /*@__PURE__*/ (() =>
+  globalThis.process.getBuiltinModule("crypto")?.hash)();
 
 /**
  * Hashes a string using the SHA-256 algorithm and encodes it in Base64URL format.
@@ -8,10 +13,8 @@ import { createHash, hash } from "node:crypto";
  * @returns {string} The hash of the data.
  */
 export function digest(data: string): string {
-  if (hash) {
-    // Available in Node.js v21.7.0+, v20.12.0+
-    // https://nodejs.org/api/crypto.html#cryptohashalgorithm-data-outputencoding
-    return hash("sha256", data, "base64url");
+  if (fastHash) {
+    return fastHash("sha256", data, "base64url");
   }
 
   const h = createHash("sha256").update(data);

--- a/src/crypto/node/index.ts
+++ b/src/crypto/node/index.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 // Available in Node.js v21.7.0+, v20.12.0+
 // https://nodejs.org/api/crypto.html#cryptohashalgorithm-data-outputencoding
 const fastHash = /*@__PURE__*/ (() =>
-  globalThis.process.getBuiltinModule("crypto")?.hash)();
+  globalThis.process?.getBuiltinModule?.("crypto")?.hash)();
 
 /**
  * Hashes a string using the SHA-256 algorithm and encodes it in Base64URL format.


### PR DESCRIPTION
regression from #116 in 2.0.3

in (ESM) environments that `hash` named export does not exist from `node:crypto`, Node.js fails.

Using default export is also not best option as in environments with hybrid polyfills (nitro and cloudflare workers), it means whole exports (both native and polyfills) are pulled in unnecessarily.

This PR uses new Node.js `process.getBuiltinModule` API to fix it.

Also big surprise there is huge bump in benchmarks! `1,158,352.39` => `2,074,725.02` not really sure what deoptimization before was kicking in.. (from ESM perhaps?)