### PR TITLE
fix: serialization format of typed arrays

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -190,5 +190,17 @@ const Serializer = /*@__PURE__*/ (function () {
       this.write(`${type}[${Array.prototype.slice.call(arr).join(",")}]`);
     };
   }
+
+  for (const type of ["BigInt64Array", "BigUint64Array"] as const) {
+    // @ts-ignore
+    Serializer.prototype["$" + type] = function (arr: ArrayBufferLike) {
+      this.write(
+        `${type}[${Array.prototype.slice
+          .call(arr)
+          .map((n) => `${n}n`)
+          .join(",")}]`,
+      );
+    };
+  }
   return Serializer;
 })();

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -175,13 +175,13 @@ const Serializer = /*@__PURE__*/ (function () {
   }
 
   for (const type of [
+    "Int8Array",
     "Uint8Array",
     "Uint8ClampedArray",
-    "Unt8Array",
+    "Int16Array",
     "Uint16Array",
-    "Unt16Array",
+    "Int32Array",
     "Uint32Array",
-    "Unt32Array",
     "Float32Array",
     "Float64Array",
   ] as const) {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { build } from "esbuild";
 import { fileURLToPath } from "node:url";
 import zlib from "node:zlib";
-import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
 
 describe("bundle size", () => {
   it("digest (js)", async () => {
@@ -22,8 +22,8 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(2400); // <2.4kb
-    expect(gzipSize).toBeLessThanOrEqual(1000); // <1kb
+    expect(bytes).toBeLessThanOrEqual(2500); // <2.5kb
+    expect(gzipSize).toBeLessThanOrEqual(1100); // <1.1kb
   });
 
   it("hash", async () => {
@@ -33,7 +33,7 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(2500); // <2.5kb
+    expect(bytes).toBeLessThanOrEqual(2700); // <2.7kb
     expect(gzipSize).toBeLessThanOrEqual(1100); // <1.1kb
   });
 });

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -22,8 +22,8 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(2500); // <2.5kb
-    expect(gzipSize).toBeLessThanOrEqual(1100); // <1.1kb
+    expect(bytes).toBeLessThanOrEqual(2600); // <2.6kb
+    expect(gzipSize).toBeLessThanOrEqual(1200); // <1.2kb
   });
 
   it("hash", async () => {
@@ -33,8 +33,8 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(2700); // <2.7kb
-    expect(gzipSize).toBeLessThanOrEqual(1200); // <1.2kb
+    expect(bytes).toBeLessThanOrEqual(2900); // <2.9kb
+    expect(gzipSize).toBeLessThanOrEqual(1300); // <1.3kb
   });
 });
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -154,6 +154,18 @@ describe("serialize", () => {
       );
     });
 
+    it("BigInt64Array", () => {
+      expect(serialize(new BigInt64Array([1n, 2n, 3n]))).toMatchInlineSnapshot(
+        `"BigInt64Array[1n,2n,3n]"`,
+      );
+    });
+
+    it("BigUint64Array", () => {
+      expect(serialize(new BigUint64Array([1n, 2n, 3n]))).toMatchInlineSnapshot(
+        `"BigUint64Array[1n,2n,3n]"`,
+      );
+    });
+
     it("Buffer and ArrayBufferLike", () => {
       expect(serialize(new Uint8Array([1, 2, 3]).buffer)).toMatchInlineSnapshot(
         `"ArrayBuffer[1,2,3]"`,

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -100,13 +100,63 @@ describe("serialize", () => {
       expect(serialize([2, 3, "x", 1])).toMatchInlineSnapshot(`"[2,3,'x',1,]"`);
     });
 
-    it("Uint8Array, Buffer and ArrayBufferLike", () => {
-      expect(serialize(new Uint8Array([1, 2, 3]).buffer)).toMatchInlineSnapshot(
-        `"ArrayBuffer[1,2,3]"`,
+    it("Int8Array", () => {
+      expect(serialize(new Int8Array([1, 2, 3]))).toMatchInlineSnapshot(
+        `"Int8Array[1,2,3]"`,
       );
+    });
 
+    it("Uint8Array", () => {
       expect(serialize(new Uint8Array([1, 2, 3]))).toMatchInlineSnapshot(
         `"Uint8Array[1,2,3]"`,
+      );
+    });
+
+    it("Uint8ClampedArray", () => {
+      expect(serialize(new Uint8ClampedArray([1, 2, 3]))).toMatchInlineSnapshot(
+        `"Uint8ClampedArray[1,2,3]"`,
+      );
+    });
+
+    it("Int16Array", () => {
+      expect(serialize(new Int16Array([1, 2, 3]))).toMatchInlineSnapshot(
+        `"Int16Array[1,2,3]"`,
+      );
+    });
+
+    it("Uint16Array", () => {
+      expect(serialize(new Uint16Array([1, 2, 3]))).toMatchInlineSnapshot(
+        `"Uint16Array[1,2,3]"`,
+      );
+    });
+
+    it("Int32Array", () => {
+      expect(serialize(new Int32Array([1, 2, 3]))).toMatchInlineSnapshot(
+        `"Int32Array[1,2,3]"`,
+      );
+    });
+
+    it("Uint32Array", () => {
+      expect(serialize(new Uint32Array([1, 2, 3]))).toMatchInlineSnapshot(
+        `"Uint32Array[1,2,3]"`,
+      );
+    });
+
+    it("Float32Array", () => {
+      expect(serialize(new Float32Array([1, 2, 3]))).toMatchInlineSnapshot(
+        `"Float32Array[1,2,3]"`,
+      );
+    });
+
+    it("Float64Array", () => {
+      expect(serialize(new Float64Array([1, 2, 3]))).toMatchInlineSnapshot(
+        `"Float64Array[1,2,3]"`,
+      );
+    });
+
+    it("Buffer and ArrayBufferLike", () => {
+      expect(serialize(new Uint8Array([1, 2, 3]).buffer)).toMatchInlineSnapshot(
+        `"ArrayBuffer[1,2,3]"`,
       );
 
       expect(serialize(Buffer.from("hello"))).toMatchInlineSnapshot(


### PR DESCRIPTION
Resolves #120

- Added serialization tests for all typed arrays (except for `Float16Array` which is not yet supported, should we add it?)
- Corrected typos in Serializer 
- Added support for BigInt64Array and BigUint64Array