### PR TITLE
perf(serialize): fast path to compare primitive values

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -31,13 +31,9 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     compare(a: any, b: any): number {
-      const cA = toComparableString(a);
-      const cB = toComparableString(b);
-      if (cA !== undefined && cB !== undefined) {
-        return cA.localeCompare(cB);
-      }
-      return _serialize(a, this.#context).localeCompare(
-        _serialize(b, this.#context),
+      return String.prototype.localeCompare.call(
+        toComparableString(a) ?? _serialize(a, this.#context),
+        toComparableString(b) ?? _serialize(b, this.#context),
       );
     }
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -31,8 +31,10 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     compare(a: any, b: any): number {
-      if (typeof a === "string" && typeof b === "string") {
-        return a.localeCompare(b);
+      const cA = toComparableString(a);
+      const cB = toComparableString(b);
+      if (cA !== undefined && cB !== undefined) {
+        return cA.localeCompare(cB);
       }
       return _serialize(a, this.#context).localeCompare(
         _serialize(b, this.#context),
@@ -206,3 +208,14 @@ const Serializer = /*@__PURE__*/ (function () {
   }
   return Serializer;
 })();
+
+function toComparableString(val: unknown): string | undefined {
+  if (val === null) {
+    return "null";
+  }
+  const type = typeof val;
+  if (type === "symbol" || type === "function" || type === "object") {
+    return undefined;
+  }
+  return String(val);
+}


### PR DESCRIPTION
Serialize sorts keys in objects/maps and values in Arrays and Sets. 

Map keys and Array/Set values to compare can be any type.

When both values (to compare) are string, it uses the fast path to avoid full serialization.

This PR makes use of fast path for wider cases (number, boolean, bigint, null, undefined) to use same fast path (it is same behavior of Array.sort()).

(only symbol, function and objects will go to full serializer after this change)