### PR TITLE
test(benchmarks): add `serialize` presets

### DIFF
--- a/test/benchmarks.bench.ts
+++ b/test/benchmarks.bench.ts
@@ -1,11 +1,11 @@
 import { bench, describe } from "vitest";
 
+import { serialize } from "../src";
 import { digest as digestJS } from "../src/crypto/js";
 import { digest as digestNode } from "../src/crypto/node";
-import { serialize } from "../src";
 
 describe("benchmarks", () => {
-  describe.only("digest", async () => {
+  describe("digest", async () => {
     const input = "hello world";
     const output = "uU0nuZNNPgilLlLX2n2r-sSE7-N6U4DukIj3rOLvzek";
     const implementations = {
@@ -28,9 +28,63 @@ describe("benchmarks", () => {
   });
 
   describe("serialize", () => {
-    bench("serialize", () => {
-      serialize({ foo: "bar", bar: new Date(0), bool: false });
-    });
+    const presets: BenchObjectPreset[] = [
+      { count: 1, size: "small" },
+      { count: 1, size: "small", circular: true },
+      { count: 1, size: "large" },
+      { count: 1, size: "large", circular: true },
+      {
+        count: 1024,
+        size: "small",
+        referenced: true,
+      },
+      {
+        count: 1024,
+        size: "small",
+        circular: true,
+        referenced: true,
+      },
+      {
+        count: 512,
+        size: "large",
+        referenced: true,
+      },
+      {
+        count: 512,
+        size: "large",
+        circular: true,
+        referenced: true,
+      },
+      {
+        count: 256,
+        size: "small",
+      },
+      {
+        count: 256,
+        size: "small",
+        circular: true,
+      },
+      {
+        count: 128,
+        size: "large",
+      },
+      {
+        count: 128,
+        size: "large",
+        circular: true,
+      },
+    ];
+
+    for (const preset of presets) {
+      const title = JSON.stringify(preset)
+        .replace(/[{"}]/g, "")
+        .replace(/,/g, ", ");
+      const objects = createBenchObjects(preset);
+
+      bench(title, () => {
+        serialize(objects);
+      });
+    }
   });
 });
 
@@ -49,4 +103,112 @@ function subtleCryptoWithNodeBuffer(input: string) {
   return crypto.subtle
     .digest("SHA-256", encoder.encode(input))
     .then((hash) => Buffer.from(hash).toString("base64url"));
+}
+
+type BenchObjectPreset = {
+  count: number;
+  size: "small" | "large";
+  circular?: boolean;
+  referenced?: boolean;
+};
+
+function createBenchObjects({
+  count = 100,
+  size = "small",
+  circular = false,
+  referenced = false,
+}: BenchObjectPreset) {
+  let object: Record<string, any> = {
+    string: "test",
+    number: 42,
+    boolean: true,
+    nullValue: null,
+    undefinedValue: undefined,
+    date: new Date(0),
+  };
+
+  if (size === "large") {
+    object = {
+      ...object,
+      regex: /.*/,
+      url: new URL("https://example.com"),
+      symbol: Symbol("test"),
+      bigint: 9_007_199_254_740_991n,
+      set: new Set([1, 2, 3, {}]),
+      map: new Map<any, any>([["key", "value"]]),
+      array: [1, 2, "x", 3],
+      int8Array: new Int8Array([1, 2, 3]),
+      uint8Array: new Uint8Array([1, 2, 3]),
+      uint8ClampedArray: new Uint8ClampedArray([1, 2, 3]),
+      int16Array: new Int16Array([1, 2, 3]),
+      uint16Array: new Uint16Array([1, 2, 3]),
+      int32Array: new Int32Array([1, 2, 3]),
+      uint32Array: new Uint32Array([1, 2, 3]),
+      float32Array: new Float32Array([1, 2, 3]),
+      float64Array: new Float64Array([1, 2, 3]),
+      bigInt64Array: new BigInt64Array([1n, 2n, 3n]),
+      bigUint64Array: new BigUint64Array([1n, 2n, 3n]),
+      buffer: Buffer.from("hello"),
+      nestedObject: { a: 1, b: 2 },
+      classInstance: new (class Test {
+        x = 1;
+      })(),
+      toJSONInstance: new (class Test {
+        toJSON() {
+          return [1, 2, 3];
+        }
+      })(),
+      formData: (() => {
+        const form = new FormData();
+        form.set("foo", "bar");
+        form.set("bar", "baz");
+        return form;
+      })(),
+      nativeFunction: Array,
+      customFunction: function sum(a: number, b: number) {
+        return a + b;
+      },
+      arrowFunction: (a: number, b: number) => a + b,
+      asyncFunction: async (a: number, b: number) => a + b,
+      generatorFunction: function* () {
+        yield 1;
+        yield 2;
+        yield 3;
+      },
+      asyncGeneratorFunction: async function* () {
+        yield 1;
+        yield 2;
+        yield 3;
+      },
+      circular: {},
+    };
+  }
+
+  if (circular) {
+    if (size === "small") {
+      object.circular = object;
+    }
+
+    if (size === "large") {
+      const circularObject = { ...object };
+
+      circularObject.circular = object;
+      circularObject.map.set("object", object);
+      circularObject.set.add(object);
+      circularObject.set.add(circularObject);
+
+      object.circular = circularObject;
+      object.map.set("object", object);
+      object.map.set("clonedObject", circularObject);
+      object.set.add(object);
+      object.set.add(circularObject);
+    }
+  }
+
+  const objects = [];
+  for (let i = 0; i < count; i++) {
+    objects.push(referenced ? object : { ...object });
+  }
+
+  return objects;
 }


### PR DESCRIPTION
This PR adds proper benchmark for `serialize()` with presets.

```scala
 ✓ test/benchmarks.bench.ts > benchmarks > serialize 7423ms
     name                                                            hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · count:1, size:small                                     477,263.18  0.0019  0.2646  0.0021  0.0020  0.0037  0.0039  0.0123  ±0.45%   238632   fastest
   · count:1, size:small, circular:true                      308,090.19  0.0029  0.2285  0.0032  0.0032  0.0044  0.0055  0.0169  ±0.24%   154046
   · count:1, size:large                                      43,778.31  0.0197  0.7381  0.0228  0.0217  0.0443  0.0572  0.5127  ±1.28%    21890
   · count:1, size:large, circular:true                       25,026.26  0.0350  3.1461  0.0400  0.0383  0.0760  0.0947  0.4402  ±1.59%    12514
   · count:1024, size:small, referenced:true                  19,491.34  0.0490  0.2771  0.0513  0.0499  0.0822  0.1474  0.2086  ±0.42%     9746
   · count:1024, size:small, circular:true, referenced:true   19,468.93  0.0487  0.3414  0.0514  0.0498  0.0834  0.1719  0.2608  ±0.53%     9735
   · count:512, size:large, referenced:true                   20,552.60  0.0434  0.6116  0.0487  0.0464  0.0834  0.1371  0.4935  ±1.11%    10277
   · count:512, size:large, circular:true, referenced:true    17,331.11  0.0512  1.1328  0.0577  0.0553  0.1037  0.2694  0.5161  ±1.09%     8666
   · count:256, size:small                                     3,726.48  0.2481  0.6942  0.2683  0.2575  0.5338  0.5686  0.6675  ±0.92%     1864
   · count:256, size:small, circular:true                      3,167.05  0.2863  2.1334  0.3158  0.2992  0.5691  0.6254  0.9258  ±1.24%     1584
   · count:128, size:large                                       895.99  1.0067  2.2416  1.1161  1.0742  1.8618  1.9411  2.2416  ±1.74%      448
   · count:128, size:large, circular:true                        866.93  1.0053  2.7256  1.1535  1.0940  2.0025  2.0748  2.7256  ±2.07%      434   slowest
   ```