### PR TITLE
perf(serialize): faster symbol and number comparison

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -98,10 +98,6 @@ const Serializer = /*@__PURE__*/ (function () {
       return `'${string}'`;
     }
 
-    $symbol(symbol: symbol) {
-      return symbol.toString();
-    }
-
     $bigint(bigint: bigint) {
       return `${bigint}n`;
     }
@@ -156,11 +152,15 @@ const Serializer = /*@__PURE__*/ (function () {
     }
   }
 
-  for (const type of ["boolean", "number", "null", "undefined"] as const) {
+  for (const type of [
+    "symbol",
+    "boolean",
+    "number",
+    "null",
+    "undefined",
+  ] as const) {
     // @ts-ignore
-    Serializer.prototype["$" + type] = function (val: any) {
-      return `${val}`;
-    };
+    Serializer.prototype["$" + type] = String;
   }
 
   for (const type of ["Error", "RegExp", "URL"] as const) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -22,9 +22,12 @@ const Serializer = /*@__PURE__*/ (function () {
     #context = new Map();
 
     compare(a: any, b: any): number {
+      if (typeof a === "number" && typeof b === "number") {
+        return a - b;
+      }
+
       // Uses fast path to compare primitive values (string, number, bigint, boolean, null, undefined)
       // Only symbol, function and object values need to be full serialized
-      // TODO: we could make it faster by fast path if both sides are numbers (need benchmarks first)
       return String.prototype.localeCompare.call(
         toComparableString(a) ?? this.serialize(a),
         toComparableString(b) ?? this.serialize(b),

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -11,32 +11,23 @@
  * @return {string} serialized string value
  */
 export function serialize(input: any): string {
-  return _serialize(input);
-}
-
-function _serialize(input: any, context?: Map<any, string>): string {
   if (typeof input === "string") {
     return `'${input}'`;
   }
-  const serializer = new Serializer(context);
-  return serializer.serialize(input);
+  return new Serializer().serialize(input);
 }
 
 const Serializer = /*@__PURE__*/ (function () {
   class Serializer {
-    #context: Map<any, string>;
-
-    constructor(context = new Map()) {
-      this.#context = context;
-    }
+    #context = new Map();
 
     compare(a: any, b: any): number {
       // Uses fast path to compare primitive values (string, number, bigint, boolean, null, undefined)
       // Only symbol, function and object values need to be full serialized
       // TODO: we could make it faster by fast path if both sides are numbers (need benchmarks first)
       return String.prototype.localeCompare.call(
-        toComparableString(a) ?? _serialize(a, this.#context),
-        toComparableString(b) ?? _serialize(b, this.#context),
+        toComparableString(a) ?? this.serialize(a),
+        toComparableString(b) ?? this.serialize(b),
       );
     }
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -204,7 +204,7 @@ function toComparableString(val: unknown): string | undefined {
     return "null";
   }
   const type = typeof val;
-  if (type === "symbol" || type === "function" || type === "object") {
+  if (type === "function" || type === "object") {
     return undefined;
   }
   return String(val);

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -166,7 +166,7 @@ const Serializer = /*@__PURE__*/ (function () {
   for (const type of ["Error", "RegExp", "URL"] as const) {
     // @ts-ignore
     Serializer.prototype["$" + type] = function (val: any) {
-      return `${type}(${val.toString()})`;
+      return `${type}(${val})`;
     };
   }
 

--- a/test/benchmarks.bench.ts
+++ b/test/benchmarks.bench.ts
@@ -202,6 +202,12 @@ function createBenchObjects({
       object.map.set("clonedObject", circularObject);
       object.set.add(object);
       object.set.add(circularObject);
+
+      for (let i = 0; i < 1000; i++) {
+        object.set.add(i);
+        object.set.add(Symbol(i));
+        object.set.add(`${i}`);
+      }
     }
   }
 


### PR DESCRIPTION
#### Changes:
1. Using external `serialize()` within `compare()` is not needed anymore, so we can reuse the same instance for these.
2. Updated benchmark to add 1000 symbols/strings/numbers to a `Set` for "large" test objects, to measure comparisons.
3. Symbols should not be excluded from the fast path so I removed it in `toComparableString()` :
```scala
// Preset: count:128, size:large, circular:true
 ✓ test/benchmarks.bench.ts > benchmarks > serialize 622ms
     name               hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · Symbol before  333.66  2.6509  4.7254  2.9971  2.9776  4.6759  4.7254  4.7254  ±2.23%      167
   · Symbol after   456.33  1.9889  3.2223  2.1914  2.2512  2.9678  3.0131  3.2223  ±1.23%      229
```

`Serializer` can handle symbols like other simple types (using `String`) to I refactored it to use that and removed an unnecessary `toString()` (for smaller bundle size).

4. Added fast path for comparing numbers:

```scala
// Preset: count:128, size:large, circular:true (only with tons of numbers in the mentioned `Set`)
 ✓ test/benchmarks.bench.ts > benchmarks > serialize >  668ms
     name                            hz      min      max    mean       p75      p99     p995     p999      rme  samples
   · Number fastpath  		 102.10   9.3314  12.6650   9.7942   9.8607  12.6650  12.6650  12.6650   ±1.40%       52
   · Number localeCompare       52.7991  13.4019  29.3478  18.9397  23.3675  29.3478  29.3478  29.3478  ±10.10%       27
```

#### Benchmark:

1000 items in the `Set` (default in bench now):
```scala
// All presets
 ✓ test/benchmarks.bench.ts > benchmarks > serialize 1271ms
     name                  hz     min      max    mean     p75      p99     p995     p999     rme  samples
   · serialize @ main  105.60  8.7689  12.3781  9.4701  9.6067  12.3781  12.3781  12.3781  ±1.82%       53
   · serialize         139.21  6.6031   8.2234  7.1833  7.3697   8.2234   8.2234   8.2234  ±1.20%       70   fastest

 BENCH  Summary

  serialize - test/benchmarks.bench.ts > benchmarks > serialize
    1.32x faster than serialize @ main
```

10 000 items in the `Set`:
```scala
// All presets
 ✓ test/benchmarks.bench.ts > benchmarks > serialize 1966ms
     name                   hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · serialize @ main  15.4536  61.3695  70.4366  64.7100  66.6816  70.4366  70.4366  70.4366  ±3.46%       10
   · serialize         25.2234  38.6651  41.4244  39.6457  40.2438  41.4244  41.4244  41.4244  ±1.17%       13   fastest

 BENCH  Summary

  serialize - test/benchmarks.bench.ts > benchmarks > serialize
    1.63x faster than serialize @ main
```