### PR TITLE
build: add `digest` and `serialize` exports for forward compat (v1)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
-export { objectHash } from "./object-hash";
+export { objectHash, objectHash as serialize /* v2 */ } from "./object-hash";
 export { hash } from "./hash";
 export { murmurHash } from "./crypto/murmur";
-export { sha256, sha256base64 } from "./crypto/sha256";
+export {
+  sha256,
+  sha256base64,
+  sha256base64 as digest /* v2 */,
+} from "./crypto/sha256";
 export { isEqual } from "./utils";
 export { diff } from "./diff";


### PR DESCRIPTION
ohash v2 renamed `sha256base64` to `digest` and `objectHash` to `serialize` however if ohash v1 is wrongly hoisted where ohash v2 is expected it can cause issues.

This PR adds alias subpath exports to ohash v1:
- `digest` => `sha256base64`
- `serialize` => `objectHash`