### PR TITLE
perf(serialize): faster `Date` serialization

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -138,7 +138,7 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     $Date(date: any) {
-      return `Date(${date.toJSON()})`;
+      return `Date(${date.toISOString()})`;
     }
 
     $ArrayBuffer(arr: ArrayBuffer) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -138,7 +138,11 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     $Date(date: any) {
-      return `Date(${date.toISOString()})`;
+      try {
+        return `Date(${date.toISOString()})`;
+      } catch {
+        return `Date(null)`;
+      }
     }
 
     $ArrayBuffer(arr: ArrayBuffer) {

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -17,6 +17,9 @@ describe("serialize", () => {
       expect(serialize(new Date(0))).toMatchInlineSnapshot(
         `"Date(1970-01-01T00:00:00.000Z)"`,
       );
+      expect(serialize(new Date(Number.NaN))).toMatchInlineSnapshot(
+        `"Date(null)"`,
+      );
     });
 
     it("boolean", () => {


### PR DESCRIPTION
`Date.toISOString()` is much faster than `toJSON()` and returns the same format.
I benchmarked `serialize()` with additional 1000 date objects.

```scala
 ✓ test/benchmarks.bench.ts > benchmarks > Date 1785ms
     name                          hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · Date.toISOString()  2,256,969.39  0.0004  0.2888  0.0004  0.0004  0.0008  0.0008  0.0015  ±0.40%  1128485   fastest
   · Date.toJSON()       1,444,250.83  0.0006  0.1528  0.0007  0.0007  0.0011  0.0011  0.0015  ±0.14%   722126

 BENCH  Summary

  Date.toISOString() - test/benchmarks.bench.ts > benchmarks > Date
    1.56x faster than Date.toJSON()
	
 ✓ test/benchmarks.bench.ts > benchmarks > all presets 1333ms
     name                   hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · serialize @ main  62.5616  14.8236  21.0751  15.9842  16.1018  21.0751  21.0751  21.0751  ±3.38%       32
   · serialize         79.8674  11.7150  14.3955  12.5207  12.7297  14.3955  14.3955  14.3955  ±1.22%       41   fastest

 BENCH  Summary

  serialize - test/benchmarks.bench.ts > benchmarks > all presets
    1.28x faster than serialize @ main
 ```