### PR TITLE
fix(serialize): handling objects with null constructors

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -77,7 +77,7 @@ const Serializer = /*@__PURE__*/ (function () {
         }
         throw new Error(`Cannot serialize ${objType}`);
       }
-      
+
       const constructorName = object.constructor?.name;
       const objName =
         constructorName === "Object" || constructorName === undefined

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -77,9 +77,12 @@ const Serializer = /*@__PURE__*/ (function () {
         }
         throw new Error(`Cannot serialize ${objType}`);
       }
-
-      const constructorName = object.constructor.name;
-      const objName = constructorName === "Object" ? "" : constructorName;
+      
+      const constructorName = object.constructor?.name;
+      const objName =
+        constructorName === "Object" || constructorName === undefined
+          ? ""
+          : constructorName;
 
       if (typeof object.toJSON === "function") {
         return objName + this.$object(object.toJSON());

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -180,8 +180,8 @@ describe("serialize", () => {
   describe("object", () => {
     it("object", () => {
       expect(serialize({ a: 1, b: 2 })).toMatchInlineSnapshot(`"{a:1,b:2}"`);
-
       expect(serialize({ b: 2, a: 1 })).toMatchInlineSnapshot(`"{a:1,b:2}"`);
+      expect(serialize(Object.create(null))).toBe("{}");
     });
 
     it("symbol key", () => {
@@ -214,10 +214,6 @@ describe("serialize", () => {
       expect(serialize(form)).toMatchInlineSnapshot(
         `"FormData{bar:'baz',foo:'bar'}"`,
       );
-    });
-
-    it("should handle special edge cases", () => {
-      expect(serialize(Object.create(null))).toBe("{}");
     });
   });
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -215,6 +215,10 @@ describe("serialize", () => {
         `"FormData{bar:'baz',foo:'bar'}"`,
       );
     });
+
+    it("should handle special edge cases", () => {
+      expect(serialize(Object.create(null))).toBe("{}");
+    });
   });
 
   describe("function", () => {


### PR DESCRIPTION
Fixes the following problem:
```ts
serialize(Object.create(null)); //TypeError: Cannot read properties of undefined (reading 'name')
```