### PR TITLE
perf(serialize): faster serialization of typed arrays and objects with string keys

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -63,7 +63,7 @@ const Serializer = /*@__PURE__*/ (function () {
       const objString = Object.prototype.toString.call(object);
 
       if (objString !== "[object Object]") {
-        return this.serializeGlobalType(
+        return this.serializeBuiltInType(
           objString.length < 10 /* '[object a]'.length === 10, the minimum */
             ? `unknown:${objString}`
             : objString.slice(8, -1) /* '[object '.length === 8 */,
@@ -78,7 +78,7 @@ const Serializer = /*@__PURE__*/ (function () {
           : constructor.name;
 
       if (objName !== "" && objName in globalThis) {
-        return this.serializeGlobalType(objName, object);
+        return this.serializeBuiltInType(objName, object);
       }
       if (typeof object.toJSON === "function") {
         return objName + this.$object(object.toJSON());
@@ -86,7 +86,7 @@ const Serializer = /*@__PURE__*/ (function () {
       return this.serializeObjectEntries(objName, Object.entries(object));
     }
 
-    serializeGlobalType(type: string, object: any) {
+    serializeBuiltInType(type: string, object: any) {
       // @ts-expect-error
       const handler = this["$" + type];
       if (handler) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -185,16 +185,15 @@ const Serializer = /*@__PURE__*/ (function () {
   ] as const) {
     // @ts-ignore
     Serializer.prototype["$" + type] = function (arr: ArrayBufferLike) {
-      return `${type}[${Array.prototype.slice.call(arr).join(",")}]`;
+      return `${type}[${Array.prototype.join.call(arr, ",")}]`;
     };
   }
 
   for (const type of ["BigInt64Array", "BigUint64Array"] as const) {
     // @ts-ignore
     Serializer.prototype["$" + type] = function (arr: ArrayBufferLike) {
-      return `${type}[${Array.prototype.slice
-        .call(arr)
-        .map((n) => `${n}n`)
+      return `${type}[${Array.prototype.map
+        .call(arr, (n) => `${n}n`)
         .join(",")}]`;
     };
   }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -22,6 +22,10 @@ const Serializer = /*@__PURE__*/ (function () {
     #context = new Map();
 
     compare(a: any, b: any): number {
+      if (typeof a === "string" && typeof b === "string") {
+        return a.localeCompare(b);
+      }
+
       if (typeof a === "number" && typeof b === "number") {
         return a - b;
       }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -155,7 +155,7 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     $ArrayBuffer(arr: ArrayBuffer) {
-      return `ArrayBuffer[${Array.prototype.slice.call(new Uint8Array(arr)).join(",")}]`;
+      return `ArrayBuffer[${new Uint8Array(arr).join(",")}]`;
     }
 
     $Set(set: Set<any>) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,5 +1,18 @@
 // Originally based on https://github.com/puleos/object-hash v3.0.0 (MIT)
 
+type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array;
+
 /**
  * Serializes any input value into a string for hashing.
  *
@@ -186,27 +199,14 @@ const Serializer = /*@__PURE__*/ (function () {
     "Float64Array",
   ] as const) {
     // @ts-ignore
-    Serializer.prototype["$" + type] = function (
-      arr:
-        | Int8Array
-        | Uint8Array
-        | Uint8ClampedArray
-        | Int16Array
-        | Uint16Array
-        | Int32Array
-        | Uint32Array
-        | Float32Array
-        | Float64Array,
-    ) {
+    Serializer.prototype["$" + type] = function (arr: TypedArray) {
       return `${type}[${arr.join(",")}]`;
     };
   }
 
   for (const type of ["BigInt64Array", "BigUint64Array"] as const) {
     // @ts-ignore
-    Serializer.prototype["$" + type] = function (
-      arr: BigInt64Array | BigUint64Array,
-    ) {
+    Serializer.prototype["$" + type] = function (arr: TypedArray) {
       return `${type}[${arr.join("n,")}${arr.length > 0 ? "n" : ""}]`;
     };
   }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -77,7 +77,7 @@ const Serializer = /*@__PURE__*/ (function () {
           ? ""
           : constructor.name;
 
-      if (objName in globalThis) {
+      if (objName !== "" && objName in globalThis) {
         return this.serializeGlobalType(objName, object);
       }
       if (typeof object.toJSON === "function") {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -102,8 +102,7 @@ const Serializer = /*@__PURE__*/ (function () {
       let content = `${type}{`;
       for (let i = 0; i < sortedEntries.length; i++) {
         const [key, value] = sortedEntries[i];
-        content += `${key}:`;
-        content += this.serialize(value);
+        content += `${key}:${this.serialize(value)}`;
         if (i < sortedEntries.length - 1) {
           content += ",";
         }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -186,17 +186,28 @@ const Serializer = /*@__PURE__*/ (function () {
     "Float64Array",
   ] as const) {
     // @ts-ignore
-    Serializer.prototype["$" + type] = function (arr: ArrayBufferLike) {
-      return `${type}[${Array.prototype.join.call(arr, ",")}]`;
+    Serializer.prototype["$" + type] = function (
+      arr:
+        | Int8Array
+        | Uint8Array
+        | Uint8ClampedArray
+        | Int16Array
+        | Uint16Array
+        | Int32Array
+        | Uint32Array
+        | Float32Array
+        | Float64Array,
+    ) {
+      return `${type}[${arr.join(",")}]`;
     };
   }
 
   for (const type of ["BigInt64Array", "BigUint64Array"] as const) {
     // @ts-ignore
-    Serializer.prototype["$" + type] = function (arr: ArrayBufferLike) {
-      return `${type}[${Array.prototype.map
-        .call(arr, (n) => `${n}n`)
-        .join(",")}]`;
+    Serializer.prototype["$" + type] = function (
+      arr: BigInt64Array | BigUint64Array,
+    ) {
+      return `${type}[${arr.join("n,")}${arr.length > 0 ? "n" : ""}]`;
     };
   }
   return Serializer;

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -35,11 +35,14 @@ const Serializer = /*@__PURE__*/ (function () {
     #context = new Map();
 
     compare(a: any, b: any): number {
-      if (typeof a === "string" && typeof b === "string") {
+      const typeA = typeof a;
+      const typeB = typeof b;
+
+      if (typeA === "string" && typeB === "string") {
         return a.localeCompare(b);
       }
 
-      if (typeof a === "number" && typeof b === "number") {
+      if (typeA === "number" && typeB === "number") {
         return a - b;
       }
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -169,6 +169,18 @@ describe("serialize", () => {
       );
     });
 
+    it("Empty BigInt64Array", () => {
+      expect(serialize(new BigInt64Array([]))).toMatchInlineSnapshot(
+        `"BigInt64Array[]"`,
+      );
+    });
+
+    it("Empty BigUint64Array", () => {
+      expect(serialize(new BigUint64Array([]))).toMatchInlineSnapshot(
+        `"BigUint64Array[]"`,
+      );
+    });
+
     it("ArrayBufferLike", () => {
       expect(serialize(new Uint8Array([1, 2, 3]).buffer)).toMatchInlineSnapshot(
         `"ArrayBuffer[1,2,3]"`,

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -262,6 +262,27 @@ describe("serialize", () => {
     });
   });
 
+  describe("unknown object type", () => {
+    let originalToString: any;
+
+    beforeEach(() => {
+      originalToString = Object.prototype.toString;
+      Object.prototype.toString = function () {
+        return "TEST";
+      };
+    });
+
+    afterEach(() => {
+      Object.prototype.toString = originalToString;
+    });
+
+    it("throws error", () => {
+      expect(() => serialize({})).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Cannot serialize unknown:TEST]`,
+      );
+    });
+  });
+
   describe("circular references", () => {
     it("handles simple circular reference", () => {
       const obj: any = {};


### PR DESCRIPTION
### Changes

I optimized serialization of `TypedArray` types: the previous parameter in these functions was `ArrayBufferLike` which did not allow calling `join()` directly on them. I inlined the proper types and also made `BigInt64Array` and  `BigUint64Array`  serialization much faster by not calling `map()` on them.

I refactored `serializeObject()` to avoid allocating new variables and calling `String.slice()` as much as possible.

In `compare()` I added back the fastest path for comparing strings because it is noticable faster for `Record<string, any>` types than calling `serialize()` twice to get the same string back. 

### Benchmarks

The first benchmark is compared to `main`, all the others are compared to the previous commit in this PR.

#### perf(serialize): remove slicing of `ArrayBufferLike`
```scala
 ✓ test/benchmarks.bench.ts > benchmarks > count:1, size:large 1234ms
     name                     hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · serialize @ main  45,003.30  0.0180  1.1335  0.0222  0.0201  0.0472  0.0673  0.4827  ±1.51%    22502
   · serialize         53,974.54  0.0160  0.7690  0.0185  0.0175  0.0344  0.0494  0.4882  ±1.39%    26988   fastest

 BENCH  Summary

  serialize - test/benchmarks.bench.ts > benchmarks > count:1, size:large
    1.20x faster than serialize @ main
```

#### refactor(serialize): optimize and split `serializeObject()`
```scala
 ✓ test/benchmarks.bench.ts > benchmarks > count:1, size:small 1460ms
     name                          hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · serialize @ previous  602,688.85  0.0014  1.7581  0.0017  0.0016  0.0030  0.0041  0.0143  ±0.86%   301345
   · serialize             661,595.08  0.0013  0.3753  0.0015  0.0015  0.0024  0.0026  0.0054  ±0.20%   330798   fastest

 ✓ test/benchmarks.bench.ts > benchmarks > count:256, size:small 1206ms
     name                        hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · serialize @ previous  5,221.50  0.1690  1.0919  0.1915  0.1787  0.4498  0.5476  0.7555  ±1.18%     2611
   · serialize             5,881.82  0.1469  0.9240  0.1700  0.1560  0.4151  0.4390  0.6875  ±1.22%     2941   fastest

 BENCH  Summary

  serialize - test/benchmarks.bench.ts > benchmarks > count:1, size:small
    1.10x faster than serialize @ previous

  serialize - test/benchmarks.bench.ts > benchmarks > count:256, size:small
    1.13x faster than serialize @ previous
```

#### perf(serialize): use the fastest path for comparing object keys
```scala
 ✓ test/benchmarks.bench.ts > benchmarks > count:1, size:small 1487ms
     name                          hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · serialize @ previous  665,950.77  0.0013  1.3253  0.0015  0.0014  0.0026  0.0028  0.0066  ±0.58%   332976
   · serialize             676,604.09  0.0013  0.2858  0.0015  0.0015  0.0024  0.0027  0.0064  ±0.18%   338303   fastest
   
 ✓ test/benchmarks.bench.ts > benchmarks > count:256, size:small 1207ms
     name                        hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · serialize @ previous  5,821.05  0.1533  1.4309  0.1718  0.1618  0.3812  0.4408  0.6446  ±1.11%     2911
   · serialize             6,239.58  0.1440  0.6091  0.1603  0.1516  0.3906  0.4261  0.5200  ±0.99%     3120   fastest

 BENCH  Summary
 
  serialize - test/benchmarks.bench.ts > benchmarks > count:1, size:small
    1.02x faster than serialize @ previous

  serialize - test/benchmarks.bench.ts > benchmarks > count:256, size:small
    1.07x faster than serialize @ previous
```

#### perf(serialize): faster TypedArray serialization

```scala

// With `new BigInt64Array(new ArrayBuffer(1_000_000))`
 ✓ test/benchmarks.bench.ts > benchmarks > count:1, size:large 1264ms
     name                       hz     min      max     mean      p75      p99     p995     p999     rme  samples
   · serialize @ previous  89.2038  8.4800  26.0450  11.2103  13.9781  26.0450  26.0450  26.0450  ±9.22%       45
   · serialize              562.50  1.5635   3.7686   1.7778   1.7988   3.3538   3.6667   3.7686  ±1.94%      282   fastest

 BENCH  Summary

  serialize - test/benchmarks.bench.ts > benchmarks > all presets
    6.31x faster than serialize @ previous
```

### Bundle size

```scala
stdout | test/bundle.test.ts > bundle size > serialize @ main
{ bytes: 2405, gzipSize: 1022 }

stdout | test/bundle.test.ts > bundle size > serialize
{ bytes: 2422, gzipSize: 1024 }
```