### PR TITLE
fix(serialize): allow `input.toJSON()` to return any type

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -98,10 +98,12 @@ const Serializer = /*@__PURE__*/ (function () {
       }
       if (typeof object.toJSON === "function") {
         const json = object.toJSON();
-        if (typeof json === "object" && json !== null) {
-          return objName + this.$object(json);
-        }
-        return objName + `(${this.serialize(json)})`;
+        return (
+          objName +
+          (typeof json === "object" && json !== null
+            ? this.$object(json)
+            : `(${this.serialize(json)})`)
+        );
       }
       return this.serializeObjectEntries(objName, Object.entries(object));
     }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -100,7 +100,7 @@ const Serializer = /*@__PURE__*/ (function () {
         const json = object.toJSON();
         return (
           objName +
-          (typeof json === "object" && json !== null
+          (json !== null && typeof json === "object"
             ? this.$object(json)
             : `(${this.serialize(json)})`)
         );

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -97,7 +97,11 @@ const Serializer = /*@__PURE__*/ (function () {
         return this.serializeBuiltInType(objName, object);
       }
       if (typeof object.toJSON === "function") {
-        return objName + this.$object(object.toJSON());
+        const json = object.toJSON();
+        if (typeof json === "object" && json !== null) {
+          return objName + this.$object(json);
+        }
+        return objName + `(${this.serialize(json)})`;
       }
       return this.serializeObjectEntries(objName, Object.entries(object));
     }

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -213,14 +213,43 @@ describe("serialize", () => {
     });
 
     it("with toJSON()", () => {
-      class Test {
+      class TestArray {
         toJSON() {
           return [1, 2, 3];
         }
       }
-      expect(serialize(new Test())).toMatchInlineSnapshot(`"Test[1,2,3]"`);
-      expect(serialize({ x: new Test() })).toMatchInlineSnapshot(
-        `"{x:Test[1,2,3]}"`,
+      expect(serialize(new TestArray())).toMatchInlineSnapshot(
+        `"TestArray[1,2,3]"`,
+      );
+      expect(serialize({ x: new TestArray() })).toMatchInlineSnapshot(
+        `"{x:TestArray[1,2,3]}"`,
+      );
+
+      class TestObject {
+        toJSON() {
+          return { a: 1, b: 2 };
+        }
+      }
+      expect(serialize(new TestObject())).toMatchInlineSnapshot(
+        `"TestObject{a:1,b:2}"`,
+      );
+
+      class TestNull {
+        toJSON() {
+          return null;
+        }
+      }
+      expect(serialize(new TestNull())).toMatchInlineSnapshot(
+        `"TestNull(null)"`,
+      );
+
+      class TestString {
+        toJSON() {
+          return "value";
+        }
+      }
+      expect(serialize(new TestString())).toMatchInlineSnapshot(
+        `"TestString('value')"`,
       );
     });
 


### PR DESCRIPTION
Currently the serializer can only handle object returns from `input.toJSON()`:

```ts
class TestString {
  toJSON() {
    return "value";
  }
}
serialize(new TestString()); // Error: Cannot serialize String
```

There is no rule that `toJSON()` must return an `object` type.

For example: 
```ts
typeof new Date().toJSON(); // string
```

I added a fix that keeps the current output format for objects, but uses `TestString('value')` format for others.