### PR TITLE
perf(serialize): faster serialization of object entries

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -114,7 +114,7 @@ const Serializer = /*@__PURE__*/ (function () {
       throw new Error(`Cannot serialize ${type}`);
     }
 
-    serializeObjectEntries(type: string, entries: Array<[string, any]>) {
+    serializeObjectEntries(type: string, entries: Array<[any, any]>) {
       const sortedEntries = entries.sort((a, b) => this.compare(a[0], b[0]));
       let content = `${type}{`;
       for (let i = 0; i < sortedEntries.length; i++) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -34,24 +34,6 @@ const Serializer = /*@__PURE__*/ (function () {
   class Serializer {
     #context = new Map();
 
-    compare(a: any, b: any): number {
-      const typeA = typeof a;
-      const typeB = typeof b;
-
-      if (typeA === "string" && typeB === "string") {
-        return a.localeCompare(b);
-      }
-
-      if (typeA === "number" && typeB === "number") {
-        return a - b;
-      }
-
-      return String.prototype.localeCompare.call(
-        this.serialize(a, true),
-        this.serialize(b, true),
-      );
-    }
-
     serialize(value: any, noQuotes?: boolean): string {
       if (value === null) {
         return "null";
@@ -173,7 +155,25 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     $Set(set: Set<any>) {
-      return `Set${this.$Array(Array.from(set).sort((a, b) => this.compare(a, b)))}`;
+      return `Set${this.$Array(
+        Array.from(set).sort((a, b) => {
+          const typeA = typeof a;
+          const typeB = typeof b;
+
+          if (typeA === "string" && typeB === "string") {
+            return a.localeCompare(b);
+          }
+
+          if (typeA === "number" && typeB === "number") {
+            return a - b;
+          }
+
+          return String.prototype.localeCompare.call(
+            this.serialize(a, true),
+            this.serialize(b, true),
+          );
+        }),
+      )}`;
     }
 
     $Map(map: Map<any, any>) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -115,9 +115,9 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     serializeObjectEntries(type: string, entries: Iterable<[string, any]>) {
-      const sortedEntries = Array.from(entries).sort((a, b) =>
-        this.compare(a[0], b[0]),
-      );
+      const sortedEntries = (
+        Array.isArray(entries) ? entries : Array.from(entries)
+      ).sort((a, b) => this.compare(a[0], b[0]));
       let content = `${type}{`;
       for (let i = 0; i < sortedEntries.length; i++) {
         const [key, value] = sortedEntries[i];

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -34,6 +34,24 @@ const Serializer = /*@__PURE__*/ (function () {
   class Serializer {
     #context = new Map();
 
+    compare(a: any, b: any): number {
+      const typeA = typeof a;
+      const typeB = typeof b;
+
+      if (typeA === "string" && typeB === "string") {
+        return a.localeCompare(b);
+      }
+
+      if (typeA === "number" && typeB === "number") {
+        return a - b;
+      }
+
+      return String.prototype.localeCompare.call(
+        this.serialize(a, true),
+        this.serialize(b, true),
+      );
+    }
+
     serialize(value: any, noQuotes?: boolean): string {
       if (value === null) {
         return "null";
@@ -155,25 +173,7 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     $Set(set: Set<any>) {
-      return `Set${this.$Array(
-        Array.from(set).sort((a, b) => {
-          const typeA = typeof a;
-          const typeB = typeof b;
-
-          if (typeA === "string" && typeB === "string") {
-            return a.localeCompare(b);
-          }
-
-          if (typeA === "number" && typeB === "number") {
-            return a - b;
-          }
-
-          return String.prototype.localeCompare.call(
-            this.serialize(a, true),
-            this.serialize(b, true),
-          );
-        }),
-      )}`;
+      return `Set${this.$Array(Array.from(set).sort((a, b) => this.compare(a, b)))}`;
     }
 
     $Map(map: Map<any, any>) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -115,7 +115,7 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     serializeObjectEntries(type: string, entries: Array<[string, any]>) {
-      const sortedEntries = entries.sort((a, b) => a[0].localeCompare(b[0]));
+      const sortedEntries = entries.sort((a, b) => this.compare(a[0], b[0]));
       let content = `${type}{`;
       for (let i = 0; i < sortedEntries.length; i++) {
         const [key, value] = sortedEntries[i];

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -115,7 +115,7 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     serializeObjectEntries(type: string, entries: Array<[string, any]>) {
-      const sortedEntries = entries.sort((a, b) => this.compare(a[0], b[0]));
+      const sortedEntries = entries.sort((a, b) => a[0].localeCompare(b[0]));
       let content = `${type}{`;
       for (let i = 0; i < sortedEntries.length; i++) {
         const [key, value] = sortedEntries[i];

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -109,15 +109,13 @@ const Serializer = /*@__PURE__*/ (function () {
         return handler.call(this, object);
       }
       if (typeof object?.entries === "function") {
-        return this.serializeObjectEntries(type, object.entries());
+        return this.serializeObjectEntries(type, Array.from(object.entries()));
       }
       throw new Error(`Cannot serialize ${type}`);
     }
 
-    serializeObjectEntries(type: string, entries: Iterable<[string, any]>) {
-      const sortedEntries = (
-        Array.isArray(entries) ? entries : Array.from(entries)
-      ).sort((a, b) => this.compare(a[0], b[0]));
+    serializeObjectEntries(type: string, entries: Array<[string, any]>) {
+      const sortedEntries = entries.sort((a, b) => this.compare(a[0], b[0]));
       let content = `${type}{`;
       for (let i = 0; i < sortedEntries.length; i++) {
         const [key, value] = sortedEntries[i];
@@ -179,7 +177,7 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     $Map(map: Map<any, any>) {
-      return this.serializeObjectEntries("Map", map.entries());
+      return this.serializeObjectEntries("Map", Array.from(map.entries()));
     }
   }
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -95,7 +95,7 @@ describe("serialize", () => {
       map.set(5, 7);
       map.set("z", 2);
       map.set("a", "1");
-      expect(serialize(map)).toMatchInlineSnapshot(`"Map{a:'1',z:2,1:3,5:7}"`);
+      expect(serialize(map)).toMatchInlineSnapshot(`"Map{1:3,5:7,a:'1',z:2}"`);
     });
   });
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -390,6 +390,28 @@ describe("serialize", () => {
     });
   });
 
+  describe("input", () => {
+    it("does not alter the input", () => {
+      const simple = {
+        a: [3, 2, 1],
+        b: {
+          z: 3,
+          y: 2,
+          x: 1,
+        },
+        set: new Set([3, 2, 1]),
+      };
+
+      const clone = { ...simple };
+
+      expect(serialize(simple)).toMatchInlineSnapshot(
+        `"{a:[3,2,1],b:{x:1,y:2,z:3},set:Set[1,2,3]}"`,
+      );
+
+      expect(clone).toStrictEqual(simple);
+    });
+  });
+
   // https://github.com/cloudflare/workerd/issues/3641
   describe("Object.prototype.toString issues", () => {
     let originalToString: any;

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -91,9 +91,11 @@ describe("serialize", () => {
 
     it("map", () => {
       const map = new Map();
+      map.set(1, 3);
+      map.set(5, 7);
       map.set("z", 2);
       map.set("a", "1");
-      expect(serialize(map)).toMatchInlineSnapshot(`"Map{a:'1',z:2}"`);
+      expect(serialize(map)).toMatchInlineSnapshot(`"Map{a:'1',z:2,1:3,5:7}"`);
     });
   });
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -389,41 +389,41 @@ describe("serialize", () => {
       expect(serialize(refs)).toMatchInlineSnapshot(`"${serialize(simple)}"`);
     });
   });
-});
 
-// https://github.com/cloudflare/workerd/issues/3641
-describe("Object.prototype.toString issues", () => {
-  let originalToString: any;
+  // https://github.com/cloudflare/workerd/issues/3641
+  describe("Object.prototype.toString issues", () => {
+    let originalToString: any;
 
-  beforeEach(() => {
-    originalToString = Object.prototype.toString;
-    Object.prototype.toString = function () {
-      return "[object Object]";
-    };
-  });
+    beforeEach(() => {
+      originalToString = Object.prototype.toString;
+      Object.prototype.toString = function () {
+        return "[object Object]";
+      };
+    });
 
-  afterEach(() => {
-    Object.prototype.toString = originalToString;
-  });
+    afterEach(() => {
+      Object.prototype.toString = originalToString;
+    });
 
-  it("URL", () => {
-    expect(serialize(new URL("https://example.com"))).toMatchInlineSnapshot(
-      `"URL(https://example.com/)"`,
-    );
-  });
+    it("URL", () => {
+      expect(serialize(new URL("https://example.com"))).toMatchInlineSnapshot(
+        `"URL(https://example.com/)"`,
+      );
+    });
 
-  it("Blob", () => {
-    expect(() => serialize(new Blob(["x"]))).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Cannot serialize Blob]`,
-    );
-  });
+    it("Blob", () => {
+      expect(() =>
+        serialize(new Blob(["x"])),
+      ).toThrowErrorMatchingInlineSnapshot(`[Error: Cannot serialize Blob]`);
+    });
 
-  it("FormData", () => {
-    const form = new FormData();
-    form.set("foo", "bar");
-    form.set("bar", "baz");
-    expect(serialize(form)).toMatchInlineSnapshot(
-      `"FormData{bar:'baz',foo:'bar'}"`,
-    );
+    it("FormData", () => {
+      const form = new FormData();
+      form.set("foo", "bar");
+      form.set("bar", "baz");
+      expect(serialize(form)).toMatchInlineSnapshot(
+        `"FormData{bar:'baz',foo:'bar'}"`,
+      );
+    });
   });
 });


### PR DESCRIPTION
### Changes
I added an extra `Array.isArray()` check in `serializeObjectEntries()` to avoid creating a new array whenever it's possible.
Sorting in `serializeObjectEntries()` always runs on entries created by the `Serializer` but I added a test to make sure the input object is not altered.

Where  `obj` can be `Array | Iterable<any>` I benchmarked if calling  `Array.isArray(obj)` is faster before calling `Array.from(obj)` on it directly:

<details>
<summary>View benchmark code</summary>

```ts
describe.only("array", () => {
  const cases: any = [Object.entries({}), Object.entries({})];
  // const cases: any = [Object.entries({}), new Map().entries()];
  // const cases: any = [new Map().entries(), new Map().entries()];

  bench("Array.isArray() before Array.from()", () => {
    for (const obj of cases) {
      const objArray = Array.isArray(obj) ? obj : Array.from(obj);
      objArray.push("");
    }
  });

  bench("Array.from() directly", () => {
    for (const obj of cases) {
      const objArray = Array.from(obj);
      objArray.push("");
    }
  });
});
```
</details>

#### Only `Array`:
```scala
 ✓ test/benchmarks.bench.ts > benchmarks > array 5471ms
     name                                            hz      min      max    mean     p75     p99    p995    p999      rme   samples
   · Array.isArray() before Array.from()  23,973,103.81   0.0000  41.2227  0.0000  0.0000  0.0000  0.0001  0.0001  ±22.42%  11986552   fastest
   · Array.from() directly                       8.3430  90.7321   199.82  119.86  146.23  199.82  199.82  199.82  ±25.69%        10

 BENCH  Summary

  Array.isArray() before Array.from() - test/benchmarks.bench.ts > benchmarks > array
    2873442.14x faster than Array.from() directly
```

#### `Array` and `Iterable<any>`:
```scala
 ✓ test/benchmarks.bench.ts > benchmarks > array 2070ms
     name                                           hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · Array.isArray() before Array.from()  6,170,484.46   0.0001   5.7207   0.0002   0.0002   0.0003   0.0003   0.0005  ±3.61%  3085243   fastest
   · Array.from() directly                     75.0912  10.7406  19.1536  13.3171  15.7131  19.1536  19.1536  19.1536  ±7.41%       38

 BENCH  Summary

  Array.isArray() before Array.from() - test/benchmarks.bench.ts > benchmarks > array
    82173.17x faster than Array.from() directly
```

#### Only `Iterable<any>`:
```scala
 ✓ test/benchmarks.bench.ts > benchmarks > array 2318ms
     name                                           hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · Array.isArray() before Array.from()  4,192,182.78  0.0002  2.1175  0.0002  0.0002  0.0004  0.0004  0.0007  ±0.87%  2096092   fastest
   · Array.from() directly                4,111,899.68  0.0002  1.6546  0.0002  0.0002  0.0004  0.0004  0.0006  ±0.71%  2055950

 BENCH  Summary

  Array.isArray() before Array.from() - test/benchmarks.bench.ts > benchmarks > array
    1.02x faster than Array.from() directly
```

### Benchmark
```scala
 ✓ test/benchmarks.bench.ts > benchmarks > serialize > count:256, size:small 1206ms
     name                       hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · serialize @ main     6,504.82  0.1332  1.7424  0.1537  0.1402  0.3435  0.4212  0.7204  ±1.32%     3253
   · serialize @ current  7,159.79  0.1288  0.4704  0.1397  0.1348  0.2932  0.3143  0.4206  ±0.65%     3580   fastest

 BENCH  Summary

  serialize @ current - test/benchmarks.bench.ts > benchmarks > serialize > count:256, size:small
    1.10x faster than serialize @ main

clk: ~5.21 GHz
cpu: AMD Ryzen 9 7950X 16-Core Processor
runtime: bun 1.2.4 (x64-linux)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• count:256, size:small
------------------------------------------- -------------------------------
serialize @ main             121.57 µs/iter 115.67 µs █▂
                      (107.52 µs … 1.54 ms) 254.81 µs ██
                    (  0.00  b … 644.00 kb)  12.35 kb ██▅▅▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

serialize                    112.12 µs/iter 105.52 µs  █
                       (95.84 µs … 1.61 ms) 220.90 µs  █
                    (  0.00  b … 528.00 kb)  18.01 kb ▂█▃▄▂▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁

summary
  serialize
   1.08x faster than serialize @ main
```