### PR TITLE
fix(serialize): serializing custom classes

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -93,7 +93,8 @@ const Serializer = /*@__PURE__*/ (function () {
           ? ""
           : constructor.name;
 
-      if (objName !== "" && objName in globalThis) {
+      // @ts-expect-error
+      if (objName !== "" && globalThis[objName] === constructor) {
         return this.serializeBuiltInType(objName, object);
       }
       if (typeof object.toJSON === "function") {

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -210,6 +210,15 @@ describe("serialize", () => {
         x = 1;
       }
       expect(serialize(new Test())).toMatchInlineSnapshot(`"Test{x:1}"`);
+
+      // "CustomEvent" key exists in `globalThis`
+      // See: https://github.com/unjs/ohash/issues/137
+      class CustomEvent {
+        y = 1;
+      }
+      expect(serialize(new CustomEvent())).toMatchInlineSnapshot(
+        `"CustomEvent{y:1}"`,
+      );
     });
 
     it("with toJSON()", () => {


### PR DESCRIPTION
Closes #137 

We can check if the provided objects constructor is the same that's in the `globalThis` instead of just the name.