### PR TITLE
fix(serialize): `Map` serialization with object keys

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -115,14 +115,14 @@ const Serializer = /*@__PURE__*/ (function () {
       throw new Error(`Cannot serialize ${type}`);
     }
 
-    serializeObjectEntries(type: string, entries: Iterable<[string, any]>) {
+    serializeObjectEntries(type: string, entries: Iterable<[any, any]>) {
       const sortedEntries = Array.from(entries).sort((a, b) =>
         this.compare(a[0], b[0]),
       );
       let content = `${type}{`;
       for (let i = 0; i < sortedEntries.length; i++) {
         const [key, value] = sortedEntries[i];
-        content += `${key}:${this.serialize(value)}`;
+        content += `${this.serialize(key, true)}:${this.serialize(value)}`;
         if (i < sortedEntries.length - 1) {
           content += ",";
         }

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -91,9 +91,15 @@ describe("serialize", () => {
 
     it("map", () => {
       const map = new Map();
+      map.set(1, 4);
+      map.set(2, 3);
       map.set("z", 2);
       map.set("a", "1");
-      expect(serialize(map)).toMatchInlineSnapshot(`"Map{a:'1',z:2}"`);
+      map.set({ x: 42 }, "3");
+
+      expect(serialize(map)).toMatchInlineSnapshot(
+        `"Map{{x:42}:'3',1:4,2:3,a:'1',z:2}"`,
+      );
     });
   });
 
@@ -341,6 +347,12 @@ describe("serialize", () => {
       const map = new Map();
       map.set("key", map);
       expect(serialize(map)).toMatchInlineSnapshot(`"Map{key:#0}"`);
+    });
+
+    it("handles circular references within keys of Map objects", () => {
+      const map = new Map();
+      map.set(map, "value");
+      expect(serialize(map)).toMatchInlineSnapshot(`"Map{#0:'value'}"`);
     });
 
     it("handles circular references within Set objects", () => {


### PR DESCRIPTION
Maps with object keys are currently serialized to wrong format.

```ts
const map = new Map();
map.set({ a: "b" }, "c");
serialize(map);  // Map{[object Object]:'c'}
```

I enabled serialization for every key in `serializeObjectEntries()` and fixed the wrong type of the `entries` param.
It now outputs: `Map{{a:'b'}:'c'}`

Added test to cover this (and also added more numeric keys to properly test the comparison within entries).
Added test where the `Map` entry key is the `Map` itself (circular).