### PR TITLE
perf(serialize): faster object entries serialization

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -116,15 +116,13 @@ const Serializer = /*@__PURE__*/ (function () {
         return handler.call(this, object);
       }
       if (typeof object?.entries === "function") {
-        return this.serializeObjectEntries(type, object.entries());
+        return this.serializeObjectEntries(type, Array.from(object.entries()));
       }
       throw new Error(`Cannot serialize ${type}`);
     }
 
-    serializeObjectEntries(type: string, entries: Iterable<[any, any]>) {
-      const sortedEntries = Array.from(entries).sort((a, b) =>
-        this.compare(a[0], b[0]),
-      );
+    serializeObjectEntries(type: string, entries: Array<[any, any]>) {
+      const sortedEntries = entries.sort((a, b) => this.compare(a[0], b[0]));
       let content = `${type}{`;
       for (let i = 0; i < sortedEntries.length; i++) {
         const [key, value] = sortedEntries[i];
@@ -186,7 +184,7 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     $Map(map: Map<any, any>) {
-      return this.serializeObjectEntries("Map", map.entries());
+      return this.serializeObjectEntries("Map", Array.from(map.entries()));
     }
   }
 


### PR DESCRIPTION
A refactored `serializeObjectEntries()` to only accept `Array` types. This way we can avoid calling `Array.from()` on `Object.entries(object)` which returns `Array<[string, any]>`.

```sc
 ✓ test/benchmarks.bench.ts > benchmarks > serialize > count:256, size:small 1208ms
     name                 hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · ohash v2.0.11  6,625.07  0.1373  2.9910  0.1509  0.1449  0.3059  0.3372  0.4453  ±1.30%     3313
   · ohash @ dev    7,061.59  0.1302  0.6451  0.1416  0.1359  0.3135  0.3418  0.3891  ±0.72%     3531   fastest

 BENCH  Summary

  ohash @ dev - test/benchmarks.bench.ts > benchmarks > serialize > count:256, size:small
    1.07x faster than ohash v2.0.11
	
clk: ~5.33 GHz
cpu: AMD Ryzen 9 7950X 16-Core Processor
runtime: bun 1.2.4 (x64-linux)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• count:256, size:small
------------------------------------------- -------------------------------
ohash v2.0.11                151.11 µs/iter 141.54 µs  █
                      (131.31 µs … 1.90 ms) 253.23 µs  █
                    (  0.00  b … 528.00 kb)  29.27 kb ▄█▃▄▂▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁

ohash @ dev                  139.86 µs/iter 132.10 µs  █
                      (122.04 µs … 1.79 ms) 217.50 µs  █
                    (  0.00  b … 528.00 kb)  21.92 kb ▁█▇▂▃▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁
                    
summary
  ohash @ dev
   1.08x faster than ohash v2.0.11
```                  