### PR TITLE
perf(serialize): faster serialization of objects and classes

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -186,7 +186,7 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     $Set(set: Set<any>) {
-      return `Set${this.$Array(Array.from(set).sort(this.compare.bind(this)))}`;
+      return `Set${this.$Array(Array.from(set).sort((a, b) => this.compare(a, b)))}`;
     }
 
     $Map(map: Map<any, any>) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -107,7 +107,7 @@ const Serializer = /*@__PURE__*/ (function () {
         );
       }
 
-      const keys = Object.keys(object).sort();
+      const keys = Object.keys(object).sort((a, b) => a.localeCompare(b));
       let content = `${objName}{`;
       for (let i = 0; i < keys.length; i++) {
         content += `${keys[i]}:${this.serialize(object[keys[i]])}`;

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -106,7 +106,16 @@ const Serializer = /*@__PURE__*/ (function () {
             : `(${this.serialize(json)})`)
         );
       }
-      return this.serializeObjectEntries(objName, Object.entries(object));
+
+      const keys = Object.keys(object).sort();
+      let content = `${objName}{`;
+      for (let i = 0; i < keys.length; i++) {
+        content += `${keys[i]}:${this.serialize(object[keys[i]])}`;
+        if (i < keys.length - 1) {
+          content += ",";
+        }
+      }
+      return content + "}";
     }
 
     serializeBuiltInType(type: string, object: any) {
@@ -121,18 +130,14 @@ const Serializer = /*@__PURE__*/ (function () {
       throw new Error(`Cannot serialize ${type}`);
     }
 
-    serializeObjectEntries(
-      type: string,
-      entries: Iterable<[any, any]> | Array<[string, any]>,
-    ) {
-      const isArray = Array.isArray(entries);
-      const sortedEntries = isArray
-        ? entries.sort((a, b) => a[0].localeCompare(b[0]))
-        : Array.from(entries).sort((a, b) => this.compare(a[0], b[0]));
+    serializeObjectEntries(type: string, entries: Iterable<[any, any]>) {
+      const sortedEntries = Array.from(entries).sort((a, b) =>
+        this.compare(a[0], b[0]),
+      );
       let content = `${type}{`;
       for (let i = 0; i < sortedEntries.length; i++) {
         const [key, value] = sortedEntries[i];
-        content += `${isArray ? key : this.serialize(key, true)}:${this.serialize(value)}`;
+        content += `${this.serialize(key, true)}:${this.serialize(value)}`;
         if (i < sortedEntries.length - 1) {
           content += ",";
         }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -97,7 +97,7 @@ const Serializer = /*@__PURE__*/ (function () {
       if (objName !== "" && globalThis[objName] === constructor) {
         return this.serializeBuiltInType(objName, object);
       }
-      if (typeof object.toJSON === "function") {
+      if ("toJSON" in object && typeof object.toJSON === "function") {
         const json = object.toJSON();
         return (
           objName +
@@ -115,7 +115,7 @@ const Serializer = /*@__PURE__*/ (function () {
       if (handler) {
         return handler.call(this, object);
       }
-      if (typeof object?.entries === "function") {
+      if ("entries" in object && typeof object.entries === "function") {
         return this.serializeObjectEntries(type, object.entries());
       }
       throw new Error(`Cannot serialize ${type}`);

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -110,7 +110,8 @@ const Serializer = /*@__PURE__*/ (function () {
       const keys = Object.keys(object).sort((a, b) => a.localeCompare(b));
       let content = `${objName}{`;
       for (let i = 0; i < keys.length; i++) {
-        content += `${keys[i]}:${this.serialize(object[keys[i]])}`;
+        const key = keys[i];
+        content += `${key}:${this.serialize(object[key])}`;
         if (i < keys.length - 1) {
           content += ",";
         }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -186,7 +186,7 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     $Set(set: Set<any>) {
-      return `Set${this.$Array(Array.from(set).sort((a, b) => this.compare(a, b)))}`;
+      return `Set${this.$Array(Array.from(set).sort(this.compare.bind(this)))}`;
     }
 
     $Map(map: Map<any, any>) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -116,17 +116,32 @@ const Serializer = /*@__PURE__*/ (function () {
         return handler.call(this, object);
       }
       if (typeof object?.entries === "function") {
-        return this.serializeObjectEntries(type, Array.from(object.entries()));
+        return this.serializeIterableEntries(type, object.entries());
       }
       throw new Error(`Cannot serialize ${type}`);
     }
 
-    serializeObjectEntries(type: string, entries: Array<[any, any]>) {
-      const sortedEntries = entries.sort((a, b) => this.compare(a[0], b[0]));
+    serializeIterableEntries(type: string, entries: Iterable<[any, any]>) {
+      const sortedEntries = Array.from(entries).sort((a, b) =>
+        this.compare(a[0], b[0]),
+      );
       let content = `${type}{`;
       for (let i = 0; i < sortedEntries.length; i++) {
         const [key, value] = sortedEntries[i];
         content += `${this.serialize(key, true)}:${this.serialize(value)}`;
+        if (i < sortedEntries.length - 1) {
+          content += ",";
+        }
+      }
+      return content + "}";
+    }
+
+    serializeObjectEntries(type: string, entries: Array<[string, any]>) {
+      const sortedEntries = entries.sort((a, b) => a[0].localeCompare(b[0]));
+      let content = `${type}{`;
+      for (let i = 0; i < sortedEntries.length; i++) {
+        const [key, value] = sortedEntries[i];
+        content += `${key}:${this.serialize(value)}`;
         if (i < sortedEntries.length - 1) {
           content += ",";
         }
@@ -184,7 +199,7 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     $Map(map: Map<any, any>) {
-      return this.serializeObjectEntries("Map", Array.from(map.entries()));
+      return this.serializeIterableEntries("Map", map.entries());
     }
   }
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -116,32 +116,23 @@ const Serializer = /*@__PURE__*/ (function () {
         return handler.call(this, object);
       }
       if (typeof object?.entries === "function") {
-        return this.serializeIterableEntries(type, object.entries());
+        return this.serializeObjectEntries(type, object.entries());
       }
       throw new Error(`Cannot serialize ${type}`);
     }
 
-    serializeIterableEntries(type: string, entries: Iterable<[any, any]>) {
-      const sortedEntries = Array.from(entries).sort((a, b) =>
-        this.compare(a[0], b[0]),
-      );
+    serializeObjectEntries(
+      type: string,
+      entries: Iterable<[any, any]> | Array<[string, any]>,
+    ) {
+      const isArray = Array.isArray(entries);
+      const sortedEntries = isArray
+        ? entries.sort((a, b) => a[0].localeCompare(b[0]))
+        : Array.from(entries).sort((a, b) => this.compare(a[0], b[0]));
       let content = `${type}{`;
       for (let i = 0; i < sortedEntries.length; i++) {
         const [key, value] = sortedEntries[i];
-        content += `${this.serialize(key, true)}:${this.serialize(value)}`;
-        if (i < sortedEntries.length - 1) {
-          content += ",";
-        }
-      }
-      return content + "}";
-    }
-
-    serializeObjectEntries(type: string, entries: Array<[string, any]>) {
-      const sortedEntries = entries.sort((a, b) => a[0].localeCompare(b[0]));
-      let content = `${type}{`;
-      for (let i = 0; i < sortedEntries.length; i++) {
-        const [key, value] = sortedEntries[i];
-        content += `${key}:${this.serialize(value)}`;
+        content += `${isArray ? key : this.serialize(key, true)}:${this.serialize(value)}`;
         if (i < sortedEntries.length - 1) {
           content += ",";
         }
@@ -199,7 +190,7 @@ const Serializer = /*@__PURE__*/ (function () {
     }
 
     $Map(map: Map<any, any>) {
-      return this.serializeIterableEntries("Map", map.entries());
+      return this.serializeObjectEntries("Map", map.entries());
     }
   }
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -125,7 +125,7 @@ const Serializer = /*@__PURE__*/ (function () {
       if (handler) {
         return handler.call(this, object);
       }
-      if ("entries" in object && typeof object.entries === "function") {
+      if (typeof object.entries === "function") {
         return this.serializeObjectEntries(type, object.entries());
       }
       throw new Error(`Cannot serialize ${type}`);


### PR DESCRIPTION
Since we know `Object.entries(object)` returns `Array<[string, any]>` we can use a faster path to:
- avoid calling `compare()` because we can call `String.localeCompare()` directly on keys
- avoid calling `serialize()` for keys because they can be only strings

~~I created a new function for handling the `Iterable` but we can also merge it to the existing `serializeObjectEntries()` with a flag like `onlyStringKeys` and add conditions to handle that.~~

~~The performance gains are not significant though.~~ - Used a faster path later.

```sc
 ✓ test/benchmarks.bench.ts > benchmarks > serialize > count:1, size:small 1446ms
     name                      hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · serialize @ main  703,004.23  0.0012  0.4631  0.0014  0.0013  0.0024  0.0026  0.0145  ±0.67%   351503
   · serialize         736,631.27  0.0012  0.2477  0.0014  0.0013  0.0021  0.0022  0.0052  ±0.30%   368316   fastest

 ✓ test/benchmarks.bench.ts > benchmarks > serialize > count:256, size:small 1206ms
     name                    hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · serialize @ main  7,052.17  0.1315  0.6230  0.1418  0.1372  0.3075  0.3213  0.3579  ±0.66%     3527
   · serialize         7,302.85  0.1276  0.3518  0.1369  0.1329  0.2274  0.2351  0.3235  ±0.48%     3652   fastest

 BENCH  Summary

  serialize - test/benchmarks.bench.ts > benchmarks > serialize > count:1, size:small
    1.05x faster than serialize @ main

  serialize - test/benchmarks.bench.ts > benchmarks > serialize > count:256, size:small
    1.04x faster than serialize @ main
```