### PR TITLE
docs: Fixed `important` callout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ console.log(hash({ foo: "bar" }));
 
 Serializes any input value into a string for hashing.
 
-> [!IMPORTANT] > `serialize` method uses best efforts to generate stable serialized values; however, it is not designed for security purposes. Keep in mind that there is always a chance of intentional collisions caused by user input.
+> [!IMPORTANT]
+> `serialize` method uses best efforts to generate stable serialized values; however, it is not designed for security purposes. Keep in mind that there is always a chance of intentional collisions caused by user input.
 
 ```js
 import { serialize } from "ohash";


### PR DESCRIPTION
Fix rendering of "important" callout under `serialize` section on readme

#### Before:

![image](https://github.com/user-attachments/assets/13ca0411-0f69-485d-9ec8-352255d6180a)


#### After:

![image](https://github.com/user-attachments/assets/73ea50cd-8a61-40a9-b86c-d0f721c478ae)

