### PR TITLE
perf(utils): faster `isEqual()` with type check

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ console.log(digest("Hello World!"));
 
 ## `isEqual(obj1, obj2)`
 
-Compare two objects using `===` and then fallbacks to compare based on their [serialized](#serializeinput) values.
+Compares two objects using `===`. If they are not strictly equal but of the same type, it falls back to compare based on their [serialized](#serializeinput) values.
 
 ```js
 import { isEqual } from "ohash";
@@ -101,7 +101,7 @@ console.log(isEqual({ a: 1, b: 2 }, { b: 2, a: 1 }));
 
 ## `diff(obj1, obj2)`
 
-Compare two objects with nested [serialization](#serializeinput-options). Returns an array of changes.
+Compares two objects with nested [serialization](#serializeinput). Returns an array of changes.
 
 The returned value is an array of diff entries with `$key`, `$hash`, `$value`, and `$props`. When logging, a string version of the changelog is displayed.
 

--- a/src/utils/is-equal.ts
+++ b/src/utils/is-equal.ts
@@ -9,8 +9,8 @@ export function isEqual(object1: any, object2: any): boolean {
   if (object1 === object2) {
     return true;
   }
-  if (serialize(object1) === serialize(object2)) {
-    return true;
+  if (typeof object1 !== typeof object2) {
+    return false;
   }
-  return false;
+  return serialize(object1) === serialize(object2);
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,14 +1,31 @@
 import { describe, expect, it } from "vitest";
-import { isEqual, diff } from "../src/utils";
+import { diff, isEqual } from "../src/utils";
 
 describe("isEqual", () => {
+  class Test {}
+
   const cases = [
     [{ foo: "bar" }, { foo: "bar" }, true],
     [{ foo: "bar" }, { foo: "baz" }, false],
+    [{ foo: "bar" }, "baz", false],
+    [{ foo: "bar" }, 1, false],
     [{ a: 1, b: 2 }, { b: 2, a: 1 }, true],
+    [123, "foo", false],
     [123, 123, true],
     [123, 456, false],
     [[1, 2], [2, 1], false],
+    ["foo", [1, 2], false],
+    ["foo", "bar", false],
+    ["foo", "foo", true],
+    [0, 1, false],
+    [1, 1, true],
+    [new Test(), new Test(), true],
+    [new (class Test2 {})(), new (class Test2 {})(), true],
+    [new Test(), new (class Test2 {})(), false],
+    [Number.NaN, Number.NaN, true],
+    [Number.NaN, 0, false],
+    [undefined, 0, false],
+    [undefined, null, false],
   ];
   for (const [obj1, obj2, equals] of cases) {
     it(`${JSON.stringify(obj1)} ${

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -17,8 +17,6 @@ describe("isEqual", () => {
     ["foo", [1, 2], false],
     ["foo", "bar", false],
     ["foo", "foo", true],
-    [0, 1, false],
-    [1, 1, true],
     [new Test(), new Test(), true],
     [new (class Test2 {})(), new (class Test2 {})(), true],
     [new Test(), new (class Test2 {})(), false],


### PR DESCRIPTION
Added additional test cases for `isEqual()`.
Optimized performance by adding a type equality check before comparing serialized versions.

Probably more conditions could be added here to make it more performant but this is the most obvious that doesn't prioritize any specific type.