### PR TITLE
perf(serialize): use quick sort for sorting everything

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -230,90 +230,10 @@ const Serializer = /*@__PURE__*/ (function () {
   return Serializer;
 })();
 
-/**
- * Efficient QuickSort with reduced bundle size
- * Uses tail-call optimization and minimizes function calls
- */
 function quickSort<T>(array: T[], compare?: (a: T, b: T) => boolean): T[] {
-  if (compare === undefined) {
-    const sortDefault = (
-      left: number = 0,
-      right: number = array.length - 1,
-    ): void => {
-      // Early return for single element
-      if (left >= right) return;
-
-      // Use insertion sort for small arrays
-      if (right - left <= 10) {
-        for (let i = left + 1; i <= right; i++) {
-          const temp = array[i];
-          let j = i;
-          while (j > left && temp < array[j - 1]) {
-            array[j] = array[j - 1];
-            j--;
-          }
-          array[j] = temp;
-        }
-        return;
-      }
-
-      // Simple pivot selection - middle element
-      const pivotIndex = Math.floor((left + right) / 2);
-      const pivot = array[pivotIndex];
-
-      // Move pivot to end temporarily
-      array[pivotIndex] = array[right];
-      array[right] = pivot;
-
-      // Partition
-      let storeIndex = left;
-      for (let i = left; i < right; i++) {
-        if (array[i] < pivot) {
-          if (i !== storeIndex) {
-            // Swap only when needed
-            const temp = array[i];
-            array[i] = array[storeIndex];
-            array[storeIndex] = temp;
-          }
-          storeIndex++;
-        }
-      }
-
-      // Put pivot in its final place
-      array[right] = array[storeIndex];
-      array[storeIndex] = pivot;
-
-      // Sort left part
-      sortDefault(left, storeIndex - 1);
-
-      // Tail call optimization - replace recursion with iteration for right part
-      left = storeIndex + 1;
-    };
-
-    sortDefault();
-    return array;
-  }
-
-  const sortCustom = (
-    left: number = 0,
-    right: number = array.length - 1,
-  ): void => {
+  const sort = (left: number = 0, right: number = array.length - 1): void => {
     // Early return for single element
     if (left >= right) return;
-
-    // Use insertion sort for small arrays
-    if (right - left <= 10) {
-      for (let i = left + 1; i <= right; i++) {
-        const temp = array[i];
-        let j = i;
-        while (j > left && compare(temp, array[j - 1])) {
-          array[j] = array[j - 1];
-          j--;
-        }
-        array[j] = temp;
-      }
-      return;
-    }
 
     // Simple pivot selection - middle element
     const pivotIndex = Math.floor((left + right) / 2);
@@ -325,15 +245,29 @@ function quickSort<T>(array: T[], compare?: (a: T, b: T) => boolean): T[] {
 
     // Partition
     let storeIndex = left;
-    for (let i = left; i < right; i++) {
-      if (compare(array[i], pivot)) {
-        if (i !== storeIndex) {
-          // Swap only when needed
-          const temp = array[i];
-          array[i] = array[storeIndex];
-          array[storeIndex] = temp;
+
+    const swap = (i: number) => {
+      if (i !== storeIndex) {
+        // Swap only when needed
+        const temp = array[i];
+        array[i] = array[storeIndex];
+        array[storeIndex] = temp;
+      }
+      storeIndex++;
+    };
+
+    // Code style: this is a micro optimization for optimal performance
+    if (compare === undefined) {
+      for (let i = left; i < right; i++) {
+        if (array[i] < pivot) {
+          swap(i);
         }
-        storeIndex++;
+      }
+    } else {
+      for (let i = left; i < right; i++) {
+        if (compare(array[i], pivot)) {
+          swap(i);
+        }
       }
     }
 
@@ -342,12 +276,13 @@ function quickSort<T>(array: T[], compare?: (a: T, b: T) => boolean): T[] {
     array[storeIndex] = pivot;
 
     // Sort left part
-    sortCustom(left, storeIndex - 1);
+    sort(left, storeIndex - 1);
 
     // Tail call optimization - replace recursion with iteration for right part
     left = storeIndex + 1;
   };
 
-  sortCustom();
+  sort();
+
   return array;
 }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -22,8 +22,8 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(3400); // <3.4kb
-    expect(gzipSize).toBeLessThanOrEqual(1500); // <1.5kb
+    expect(bytes).toBeLessThanOrEqual(3000); // <3kb
+    expect(gzipSize).toBeLessThanOrEqual(1300); // <1.3kb
   });
 
   it("hash", async () => {
@@ -33,8 +33,8 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(3700); // <3.7kb
-    expect(gzipSize).toBeLessThanOrEqual(1800); // <1.8kb
+    expect(bytes).toBeLessThanOrEqual(3400); // <3.4kb
+    expect(gzipSize).toBeLessThanOrEqual(1600); // <1.6kb
   });
 });
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -22,8 +22,8 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(3000); // <3kb
-    expect(gzipSize).toBeLessThanOrEqual(1300); // <1.3kb
+    expect(bytes).toBeLessThanOrEqual(3400); // <3.4kb
+    expect(gzipSize).toBeLessThanOrEqual(1500); // <1.5kb
   });
 
   it("hash", async () => {
@@ -33,8 +33,8 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(3400); // <3.4kb
-    expect(gzipSize).toBeLessThanOrEqual(1600); // <1.6kb
+    expect(bytes).toBeLessThanOrEqual(3700); // <3.7kb
+    expect(gzipSize).toBeLessThanOrEqual(1800); // <1.8kb
   });
 });
 


### PR DESCRIPTION
We can use `quickSort` for sorting `Set` and other arrays too.

### Compared to target: https://github.com/unjs/ohash/pull/148

```sc
 ✓ test/benchmarks.bench.ts > benchmarks > serialize - presets > count:1, size:small 2259ms
     name                       hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · ohash @ 8434bea  3,842,100.95  0.0002  3.0409  0.0003  0.0003  0.0005  0.0006  0.0007  ±1.21%  1921051
   · ohash @ dev      3,878,229.53  0.0002  2.0584  0.0003  0.0003  0.0004  0.0005  0.0008  ±0.86%  1939115   fastest

 ✓ test/benchmarks.bench.ts > benchmarks > serialize - presets > count:1, size:large 1219ms
     name                    hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · ohash @ 8434bea  13,574.99  0.0626  2.9758  0.0737  0.0736  0.1290  0.1816  0.2739  ±1.27%     6788
   · ohash @ dev      46,216.51  0.0190  4.3283  0.0216  0.0208  0.0426  0.0517  0.1531  ±1.76%    23109   fastest

 BENCH  Summary

  ohash @ dev - test/benchmarks.bench.ts > benchmarks > serialize - presets > count:1, size:small
    1.01x faster than ohash @ 8434bea

  ohash @ dev - test/benchmarks.bench.ts > benchmarks > serialize - presets > count:1, size:large
    3.40x faster than ohash @ 8434bea
```

```sc
clk: ~5.13 GHz
cpu: AMD Ryzen 9 7950X 16-Core Processor
runtime: bun 1.2.4 (x64-linux)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• count:1, size:small
------------------------------------------- -------------------------------
ohash @ 8434bea              188.35 ns/iter 180.67 ns ▇█
                    (164.72 ns … 506.32 ns) 466.47 ns ██
                    (  0.00  b … 360.00  b)   4.18  b ██▄▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

ohash @ dev                  204.06 ns/iter 191.49 ns  █
                    (176.71 ns … 547.58 ns) 449.94 ns ▂█
                    (  0.00  b … 924.00  b)  13.36  b ██▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

summary
  ohash @ 8434bea
   1.08x faster than ohash @ dev

• count:1, size:large
------------------------------------------- -------------------------------
ohash @ 8434bea               73.83 µs/iter  76.12 µs   █
                       (61.11 µs … 1.48 ms) 126.72 µs  ██
                    (  0.00  b … 528.00 kb)   9.96 kb ▂███▅▅▄▃▃▂▂▂▂▂▁▁▁▁▁▁▁

ohash @ dev                   28.10 µs/iter  29.14 µs  █
                       (21.46 µs … 1.46 ms)  60.65 µs  █
                    (  0.00  b … 264.00 kb)   2.82 kb ▂██▂▄▃▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁

summary
  ohash @ dev
   2.63x faster than ohash @ 8434bea
