### PR TITLE
perf(serialize): faster `Date` serialization

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -179,12 +179,8 @@ const Serializer = /*@__PURE__*/ (function () {
       return content + "]";
     }
 
-    $Date(date: any) {
-      try {
-        return `Date(${date.toISOString()})`;
-      } catch {
-        return `Date(null)`;
-      }
+    $Date(date: Date) {
+      return `Date(${date.valueOf()})`;
     }
 
     $ArrayBuffer(arr: ArrayBuffer) {

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -14,11 +14,12 @@ describe("serialize", () => {
     });
 
     it("date", () => {
-      expect(serialize(new Date(0))).toMatchInlineSnapshot(
-        `"Date(1970-01-01T00:00:00.000Z)"`,
+      expect(serialize(new Date(0))).toMatchInlineSnapshot(`"Date(0)"`);
+      expect(serialize(new Date(1_741_794_951_781))).toMatchInlineSnapshot(
+        `"Date(1741794951781)"`,
       );
       expect(serialize(new Date(Number.NaN))).toMatchInlineSnapshot(
-        `"Date(null)"`,
+        `"Date(NaN)"`,
       );
     });
 


### PR DESCRIPTION
This is a potentially breaking change because the output of the serialized `Date` changes.

In `node` calling `Date.toISOString()` is still very slow compared to `valueOf()`.
This makes serializing objects that contain `Date` noticably slower.


#### Date benchmark
```sc
 ✓ test/benchmarks.bench.ts > benchmarks > Date 3641ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · new Date(0).toISOString()   2,365,285.91  0.0004  0.1812  0.0004  0.0004  0.0007  0.0007  0.0012  ±0.19%  1182643
   · new Date(0).valueOf()      17,439,975.34  0.0000  0.3799  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.19%  8719988   fastest

 BENCH  Summary

  new Date(0).valueOf() - test/benchmarks.bench.ts > benchmarks > Date
    7.37x faster than new Date(0).toISOString(
 ```
 
 #### Serialization benchmark
 ```sc
 clk: ~5.23 GHz
cpu: AMD Ryzen 9 7950X 16-Core Processor
runtime: node 23.9.0 (x64-linux)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• count:1, size:small + new Date(0)
------------------------------------------- -------------------------------
ohash @ v3                     1.10 µs/iter   1.10 µs   ██▄                
                    (930.00 ns … 115.29 µs)   1.71 µs   ███                
                    (  1.18 kb … 226.72 kb)   2.27 kb ▁▂████▄▃▂▂▂▂▁▁▁▁▁▁▁▁▁
                   2.96 ipc ( 98.85% cache)   16.68 branch misses
          6.82k cycles  20.21k instructions  809.99 c-refs    9.28 c-misses

ohash @ dev                  426.01 ns/iter 430.16 ns  ▂  ▅█               
                    (409.42 ns … 555.89 ns) 483.03 ns  █▇ ██▂▂             
                    (  1.75 kb …   2.14 kb)   2.14 kb ▆███████▇▄▂▁▁▁▁▁▁▁▁▁▁
                   4.31 ipc ( 96.28% cache)    0.69 branch misses
          2.27k cycles   9.78k instructions   91.54 c-refs    3.40 c-misses

summary
  ohash @ dev
   2.59x faster than ohash @ v3
```

```sc
clk: ~5.29 GHz
cpu: AMD Ryzen 9 7950X 16-Core Processor
runtime: bun 1.2.5 (x64-linux)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• count:1, size:small+ new Date(0)
------------------------------------------- -------------------------------
ohash @ v3                   765.14 ns/iter 670.00 ns █                    
                    (530.00 ns … 517.97 µs)   2.72 µs █▆                   
                    (  0.00  b … 408.00 kb) 367.46  b ██▃▄▂▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁
                   2.43 ipc ( 97.95% cache)   18.93 branch misses
          4.54k cycles  11.03k instructions  812.30 c-refs   16.68 c-misses

ohash @ dev                  429.72 ns/iter 409.70 ns  █                   
                    (384.41 ns … 866.69 ns) 799.74 ns ▅█                   
                    (  0.00  b …   1.12 kb)  40.13  b ██▅▂▁▁▁▂▁▁▁▁▁▂▂▂▁▁▁▁▁
                   3.68 ipc ( 95.61% cache)    0.62 branch misses
          2.17k cycles   8.01k instructions   83.88 c-refs    3.68 c-misses

summary
  ohash @ dev
   1.78x faster than ohash @ v3
```