### PR TITLE
feat(serialize): support HTML elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "esbuild": "^0.25.0",
     "eslint": "^9.21.0",
     "eslint-config-unjs": "^0.4.2",
+    "happy-dom": "^17.4.4",
     "mitata": "^1.0.34",
     "prettier": "^3.5.2",
     "typescript": "^5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 22.13.5
       '@vitest/coverage-v8':
         specifier: ^3.0.7
-        version: 3.0.7(vitest@3.0.7(@types/node@22.13.5)(jiti@2.4.2)(yaml@2.7.0))
+        version: 3.0.7(vitest@3.0.7(@types/node@22.13.5)(happy-dom@17.4.4)(jiti@2.4.2)(yaml@2.7.0))
       automd:
         specifier: ^0.4.0
         version: 0.4.0(magicast@0.3.5)
@@ -29,6 +29,9 @@ importers:
       eslint-config-unjs:
         specifier: ^0.4.2
         version: 0.4.2(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      happy-dom:
+        specifier: ^17.4.4
+        version: 17.4.4
       mitata:
         specifier: ^1.0.34
         version: 1.0.34
@@ -43,7 +46,7 @@ importers:
         version: 3.5.0(typescript@5.7.3)
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/node@22.13.5)(jiti@2.4.2)(yaml@2.7.0)
+        version: 3.0.7(@types/node@22.13.5)(happy-dom@17.4.4)(jiti@2.4.2)(yaml@2.7.0)
 
 packages:
 
@@ -1328,6 +1331,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  happy-dom@17.4.4:
+    resolution: {integrity: sha512-/Pb0ctk3HTZ5xEL3BZ0hK1AqDSAUuRQitOmROPHhfUYEWpmTImwfD8vFDGADmMAX0JYgbcgxWoLFKtsWhcpuVA==}
+    engines: {node: '>=18.0.0'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2258,6 +2265,14 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2830,7 +2845,7 @@ snapshots:
       '@typescript-eslint/types': 8.25.0
       eslint-visitor-keys: 4.2.0
 
-  '@vitest/coverage-v8@3.0.7(vitest@3.0.7(@types/node@22.13.5)(jiti@2.4.2)(yaml@2.7.0))':
+  '@vitest/coverage-v8@3.0.7(vitest@3.0.7(@types/node@22.13.5)(happy-dom@17.4.4)(jiti@2.4.2)(yaml@2.7.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2844,7 +2859,7 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.7(@types/node@22.13.5)(jiti@2.4.2)(yaml@2.7.0)
+      vitest: 3.0.7(@types/node@22.13.5)(happy-dom@17.4.4)(jiti@2.4.2)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3527,6 +3542,11 @@ snapshots:
   globals@15.15.0: {}
 
   graphemer@1.4.0: {}
+
+  happy-dom@17.4.4:
+    dependencies:
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
 
   has-flag@4.0.0: {}
 
@@ -4400,7 +4420,7 @@ snapshots:
       jiti: 2.4.2
       yaml: 2.7.0
 
-  vitest@3.0.7(@types/node@22.13.5)(jiti@2.4.2)(yaml@2.7.0):
+  vitest@3.0.7(@types/node@22.13.5)(happy-dom@17.4.4)(jiti@2.4.2)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.7
       '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@22.13.5)(jiti@2.4.2)(yaml@2.7.0))
@@ -4424,6 +4444,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.5
+      happy-dom: 17.4.4
     transitivePeerDependencies:
       - jiti
       - less
@@ -4437,6 +4458,10 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -118,6 +118,9 @@ const Serializer = /*@__PURE__*/ (function () {
       if (typeof object?.entries === "function") {
         return this.serializeObjectEntries(type, Array.from(object.entries()));
       }
+      if ("outerHTML" in object) {
+        return `${type}(${object.outerHTML})`;
+      }
       throw new Error(`Cannot serialize ${type}`);
     }
 
@@ -186,6 +189,34 @@ const Serializer = /*@__PURE__*/ (function () {
     $Map(map: Map<any, any>) {
       return this.serializeObjectEntries("Map", Array.from(map.entries()));
     }
+
+    $HTMLCollection(collection: HTMLCollection) {
+      return `HTMLCollection${this.$Array(Array.from(collection))}`;
+    }
+
+    $NodeList(nodeList: NodeList) {
+      return `NodeList${this.$Array(Array.from(nodeList.values()))}`;
+    }
+
+    $Range(range: Range) {
+      return `Range(${this.serialize(range.startContainer)}:${range.startOffset},${this.serialize(range.endContainer)}:${range.endOffset})`;
+    }
+  }
+
+  for (const type of ["Comment", "Text"] as const) {
+    // @ts-ignore
+    Serializer.prototype["$" + type] = function (el: Comment | Text) {
+      return `${type}('${el.textContent}')`;
+    };
+  }
+
+  for (const type of ["DocumentFragment", "HTMLDocument"] as const) {
+    // @ts-ignore
+    Serializer.prototype["$" + type] = function (
+      doc: Document | DocumentFragment,
+    ) {
+      return `${type}${this.$Array(Array.from(doc.childNodes.values()))}`;
+    };
   }
 
   for (const type of ["Error", "RegExp", "URL"] as const) {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -22,7 +22,7 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(3200); // <3.2kb
+    expect(bytes).toBeLessThanOrEqual(3300); // <3.3kb
     expect(gzipSize).toBeLessThanOrEqual(1300); // <1.3kb
   });
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -22,8 +22,8 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(2800); // <2.8kb
-    expect(gzipSize).toBeLessThanOrEqual(1200); // <1.2kb
+    expect(bytes).toBeLessThanOrEqual(3200); // <3.2kb
+    expect(gzipSize).toBeLessThanOrEqual(1300); // <1.3kb
   });
 
   it("hash", async () => {
@@ -33,8 +33,8 @@ describe("bundle size", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log({ bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(3100); // <3.1kb
-    expect(gzipSize).toBeLessThanOrEqual(1300); // <1.3kb
+    expect(bytes).toBeLessThanOrEqual(3600); // <3.6b
+    expect(gzipSize).toBeLessThanOrEqual(1500); // <1.5kb
   });
 });
 

--- a/test/serialize.dom.test.ts
+++ b/test/serialize.dom.test.ts
@@ -1,0 +1,603 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { serialize } from "../src";
+
+describe("serialize (DOM)", () => {
+  describe("Basic HTML elements", () => {
+    it("HTMLDivElement", () => {
+      const div = document.createElement("div");
+      expect(serialize(div)).toMatchInlineSnapshot(
+        `"HTMLDivElement(<div></div>)"`,
+      );
+    });
+
+    it("HTMLSpanElement", () => {
+      const span = document.createElement("span");
+      expect(serialize(span)).toMatchInlineSnapshot(
+        `"HTMLSpanElement(<span></span>)"`,
+      );
+    });
+
+    it("HTMLAnchorElement", () => {
+      const a = document.createElement("a");
+      expect(serialize(a)).toMatchInlineSnapshot(
+        `"HTMLAnchorElement(<a></a>)"`,
+      );
+    });
+
+    it("HTMLParagraphElement", () => {
+      const p = document.createElement("p");
+      expect(serialize(p)).toMatchInlineSnapshot(
+        `"HTMLParagraphElement(<p></p>)"`,
+      );
+    });
+
+    it("HTMLPreElement", () => {
+      const pre = document.createElement("pre");
+      expect(serialize(pre)).toMatchInlineSnapshot(
+        `"HTMLPreElement(<pre></pre>)"`,
+      );
+    });
+
+    it("HTMLCodeElement", () => {
+      const code = document.createElement("code");
+      expect(serialize(code)).toMatchInlineSnapshot(
+        `"HTMLElement(<code></code>)"`,
+      );
+    });
+
+    it("HTMLHRElement", () => {
+      const hr = document.createElement("hr");
+      expect(serialize(hr)).toMatchInlineSnapshot(`"HTMLHRElement(<hr>)"`);
+    });
+
+    it("HTMLBRElement", () => {
+      const br = document.createElement("br");
+      expect(serialize(br)).toMatchInlineSnapshot(`"HTMLBRElement(<br>)"`);
+    });
+  });
+
+  describe("Form elements", () => {
+    it("HTMLInputElement", () => {
+      const input = document.createElement("input");
+      expect(serialize(input)).toMatchInlineSnapshot(
+        `"HTMLInputElement(<input>)"`,
+      );
+    });
+
+    it("HTMLButtonElement", () => {
+      const button = document.createElement("button");
+      expect(serialize(button)).toMatchInlineSnapshot(
+        `"HTMLButtonElement(<button></button>)"`,
+      );
+    });
+
+    it("HTMLSelectElement", () => {
+      const select = document.createElement("select");
+      expect(serialize(select)).toMatchInlineSnapshot(
+        `"HTMLSelectElement(<select></select>)"`,
+      );
+    });
+
+    it("HTMLTextAreaElement", () => {
+      const textarea = document.createElement("textarea");
+      expect(serialize(textarea)).toMatchInlineSnapshot(
+        `"HTMLTextAreaElement(<textarea></textarea>)"`,
+      );
+    });
+
+    it("HTMLFormElement", () => {
+      const form = document.createElement("form");
+      expect(serialize(form)).toMatchInlineSnapshot(
+        `"HTMLFormElement(<form></form>)"`,
+      );
+    });
+
+    it("HTMLLabelElement", () => {
+      const label = document.createElement("label");
+      expect(serialize(label)).toMatchInlineSnapshot(
+        `"HTMLLabelElement(<label></label>)"`,
+      );
+    });
+
+    it("HTMLFieldSetElement", () => {
+      const fieldset = document.createElement("fieldset");
+      expect(serialize(fieldset)).toMatchInlineSnapshot(
+        `"HTMLFieldSetElement(<fieldset></fieldset>)"`,
+      );
+    });
+
+    it("HTMLLegendElement", () => {
+      const legend = document.createElement("legend");
+      expect(serialize(legend)).toMatchInlineSnapshot(
+        `"HTMLLegendElement(<legend></legend>)"`,
+      );
+    });
+
+    it("HTMLOptionElement", () => {
+      const option = document.createElement("option");
+      expect(serialize(option)).toMatchInlineSnapshot(
+        `"HTMLOptionElement(<option></option>)"`,
+      );
+    });
+
+    it("HTMLOptGroupElement", () => {
+      const optgroup = document.createElement("optgroup");
+      expect(serialize(optgroup)).toMatchInlineSnapshot(
+        `"HTMLOptGroupElement(<optgroup></optgroup>)"`,
+      );
+    });
+
+    it("HTMLDataListElement", () => {
+      const datalist = document.createElement("datalist");
+      expect(serialize(datalist)).toMatchInlineSnapshot(
+        `"HTMLDataListElement(<datalist></datalist>)"`,
+      );
+    });
+  });
+
+  describe("Media elements", () => {
+    it("HTMLImageElement", () => {
+      const img = document.createElement("img");
+      expect(serialize(img)).toMatchInlineSnapshot(`"HTMLImageElement(<img>)"`);
+    });
+
+    it("HTMLAudioElement", () => {
+      const audio = document.createElement("audio");
+      expect(serialize(audio)).toMatchInlineSnapshot(
+        `"HTMLAudioElement(<audio></audio>)"`,
+      );
+    });
+
+    it("HTMLVideoElement", () => {
+      const video = document.createElement("video");
+      expect(serialize(video)).toMatchInlineSnapshot(
+        `"HTMLVideoElement(<video></video>)"`,
+      );
+    });
+
+    it("HTMLCanvasElement", () => {
+      const canvas = document.createElement("canvas");
+      expect(serialize(canvas)).toMatchInlineSnapshot(
+        `"HTMLCanvasElement(<canvas></canvas>)"`,
+      );
+    });
+
+    it("HTMLIFrameElement", () => {
+      const iframe = document.createElement("iframe");
+      expect(serialize(iframe)).toMatchInlineSnapshot(
+        `"HTMLIFrameElement(<iframe></iframe>)"`,
+      );
+    });
+
+    it("HTMLObjectElement", () => {
+      const object = document.createElement("object");
+      expect(serialize(object)).toMatchInlineSnapshot(
+        `"HTMLObjectElement(<object></object>)"`,
+      );
+    });
+  });
+
+  describe("Document structure elements", () => {
+    it("HTMLScriptElement", () => {
+      const script = document.createElement("script");
+      expect(serialize(script)).toMatchInlineSnapshot(
+        `"HTMLScriptElement(<script></script>)"`,
+      );
+    });
+
+    it("HTMLStyleElement", () => {
+      const style = document.createElement("style");
+      expect(serialize(style)).toMatchInlineSnapshot(
+        `"HTMLStyleElement(<style></style>)"`,
+      );
+    });
+
+    it("HTMLLinkElement", () => {
+      const link = document.createElement("link");
+      expect(serialize(link)).toMatchInlineSnapshot(
+        `"HTMLLinkElement(<link>)"`,
+      );
+    });
+
+    it("HTMLMetaElement", () => {
+      const meta = document.createElement("meta");
+      expect(serialize(meta)).toMatchInlineSnapshot(
+        `"HTMLMetaElement(<meta>)"`,
+      );
+    });
+
+    it("HTMLTitleElement", () => {
+      const title = document.createElement("title");
+      expect(serialize(title)).toMatchInlineSnapshot(
+        `"HTMLTitleElement(<title></title>)"`,
+      );
+    });
+
+    it("HTMLHeadElement", () => {
+      const head = document.createElement("head");
+      expect(serialize(head)).toMatchInlineSnapshot(
+        `"HTMLHeadElement(<head></head>)"`,
+      );
+    });
+
+    it("HTMLBodyElement", () => {
+      const body = document.createElement("body");
+      expect(serialize(body)).toMatchInlineSnapshot(
+        `"HTMLBodyElement(<body></body>)"`,
+      );
+    });
+
+    it("HTMLHtmlElement", () => {
+      const html = document.createElement("html");
+      expect(serialize(html)).toMatchInlineSnapshot(
+        `"HTMLHtmlElement(<html></html>)"`,
+      );
+    });
+  });
+
+  describe("Table elements", () => {
+    it("HTMLTableElement", () => {
+      const table = document.createElement("table");
+      expect(serialize(table)).toMatchInlineSnapshot(
+        `"HTMLTableElement(<table></table>)"`,
+      );
+    });
+
+    it("HTMLTableRowElement", () => {
+      const tr = document.createElement("tr");
+      expect(serialize(tr)).toMatchInlineSnapshot(
+        `"HTMLTableRowElement(<tr></tr>)"`,
+      );
+    });
+
+    it("HTMLTableCellElement (td)", () => {
+      const td = document.createElement("td");
+      expect(serialize(td)).toMatchInlineSnapshot(
+        `"HTMLTableCellElement(<td></td>)"`,
+      );
+    });
+
+    it("HTMLTableCellElement (th)", () => {
+      const th = document.createElement("th");
+      expect(serialize(th)).toMatchInlineSnapshot(
+        `"HTMLTableCellElement(<th></th>)"`,
+      );
+    });
+
+    it("HTMLTableSectionElement", () => {
+      const thead = document.createElement("thead");
+      expect(serialize(thead)).toMatchInlineSnapshot(
+        `"HTMLTableSectionElement(<thead></thead>)"`,
+      );
+    });
+
+    it("HTMLTableCaptionElement", () => {
+      const caption = document.createElement("caption");
+      expect(serialize(caption)).toMatchInlineSnapshot(
+        `"HTMLTableCaptionElement(<caption></caption>)"`,
+      );
+    });
+
+    it("HTMLTableColElement (col)", () => {
+      const col = document.createElement("col");
+      expect(serialize(col)).toMatchInlineSnapshot(
+        `"HTMLTableColElement(<col>)"`,
+      );
+    });
+
+    it("HTMLTableColElement (colgroup)", () => {
+      const colgroup = document.createElement("colgroup");
+      expect(serialize(colgroup)).toMatchInlineSnapshot(
+        `"HTMLTableColElement(<colgroup></colgroup>)"`,
+      );
+    });
+  });
+
+  describe("Heading elements", () => {
+    it("HTMLHeadingElement (h1)", () => {
+      const h1 = document.createElement("h1");
+      expect(serialize(h1)).toMatchInlineSnapshot(
+        `"HTMLHeadingElement(<h1></h1>)"`,
+      );
+    });
+
+    it("HTMLHeadingElement (h2)", () => {
+      const h2 = document.createElement("h2");
+      expect(serialize(h2)).toMatchInlineSnapshot(
+        `"HTMLHeadingElement(<h2></h2>)"`,
+      );
+    });
+
+    it("HTMLHeadingElement (h3)", () => {
+      const h3 = document.createElement("h3");
+      expect(serialize(h3)).toMatchInlineSnapshot(
+        `"HTMLHeadingElement(<h3></h3>)"`,
+      );
+    });
+
+    it("HTMLHeadingElement (h4)", () => {
+      const h4 = document.createElement("h4");
+      expect(serialize(h4)).toMatchInlineSnapshot(
+        `"HTMLHeadingElement(<h4></h4>)"`,
+      );
+    });
+
+    it("HTMLHeadingElement (h5)", () => {
+      const h5 = document.createElement("h5");
+      expect(serialize(h5)).toMatchInlineSnapshot(
+        `"HTMLHeadingElement(<h5></h5>)"`,
+      );
+    });
+
+    it("HTMLHeadingElement (h6)", () => {
+      const h6 = document.createElement("h6");
+      expect(serialize(h6)).toMatchInlineSnapshot(
+        `"HTMLHeadingElement(<h6></h6>)"`,
+      );
+    });
+  });
+
+  describe("List elements", () => {
+    it("HTMLUListElement", () => {
+      const ul = document.createElement("ul");
+      expect(serialize(ul)).toMatchInlineSnapshot(
+        `"HTMLUListElement(<ul></ul>)"`,
+      );
+    });
+
+    it("HTMLOListElement", () => {
+      const ol = document.createElement("ol");
+      expect(serialize(ol)).toMatchInlineSnapshot(
+        `"HTMLOListElement(<ol></ol>)"`,
+      );
+    });
+
+    it("HTMLLIElement", () => {
+      const li = document.createElement("li");
+      expect(serialize(li)).toMatchInlineSnapshot(`"HTMLLIElement(<li></li>)"`);
+    });
+
+    it("HTMLDListElement", () => {
+      const dl = document.createElement("dl");
+      expect(serialize(dl)).toMatchInlineSnapshot(
+        `"HTMLDListElement(<dl></dl>)"`,
+      );
+    });
+
+    it("HTMLDTElement", () => {
+      const dt = document.createElement("dt");
+      expect(serialize(dt)).toMatchInlineSnapshot(`"HTMLElement(<dt></dt>)"`);
+    });
+
+    it("HTMLDDElement", () => {
+      const dd = document.createElement("dd");
+      expect(serialize(dd)).toMatchInlineSnapshot(`"HTMLElement(<dd></dd>)"`);
+    });
+  });
+
+  describe("Semantic elements", () => {
+    it("HTMLElement (header)", () => {
+      const header = document.createElement("header");
+      expect(serialize(header)).toMatchInlineSnapshot(
+        `"HTMLElement(<header></header>)"`,
+      );
+    });
+
+    it("HTMLElement (footer)", () => {
+      const footer = document.createElement("footer");
+      expect(serialize(footer)).toMatchInlineSnapshot(
+        `"HTMLElement(<footer></footer>)"`,
+      );
+    });
+
+    it("HTMLElement (nav)", () => {
+      const nav = document.createElement("nav");
+      expect(serialize(nav)).toMatchInlineSnapshot(
+        `"HTMLElement(<nav></nav>)"`,
+      );
+    });
+
+    it("HTMLElement (main)", () => {
+      const main = document.createElement("main");
+      expect(serialize(main)).toMatchInlineSnapshot(
+        `"HTMLElement(<main></main>)"`,
+      );
+    });
+
+    it("HTMLElement (section)", () => {
+      const section = document.createElement("section");
+      expect(serialize(section)).toMatchInlineSnapshot(
+        `"HTMLElement(<section></section>)"`,
+      );
+    });
+
+    it("HTMLElement (article)", () => {
+      const article = document.createElement("article");
+      expect(serialize(article)).toMatchInlineSnapshot(
+        `"HTMLElement(<article></article>)"`,
+      );
+    });
+
+    it("HTMLElement (aside)", () => {
+      const aside = document.createElement("aside");
+      expect(serialize(aside)).toMatchInlineSnapshot(
+        `"HTMLElement(<aside></aside>)"`,
+      );
+    });
+
+    it("HTMLElement (figure)", () => {
+      const figure = document.createElement("figure");
+      expect(serialize(figure)).toMatchInlineSnapshot(
+        `"HTMLElement(<figure></figure>)"`,
+      );
+    });
+
+    it("HTMLElement (figcaption)", () => {
+      const figcaption = document.createElement("figcaption");
+      expect(serialize(figcaption)).toMatchInlineSnapshot(
+        `"HTMLElement(<figcaption></figcaption>)"`,
+      );
+    });
+  });
+
+  describe("Text formatting elements", () => {
+    it("HTMLElement (em)", () => {
+      const em = document.createElement("em");
+      expect(serialize(em)).toMatchInlineSnapshot(`"HTMLElement(<em></em>)"`);
+    });
+
+    it("HTMLElement (strong)", () => {
+      const strong = document.createElement("strong");
+      expect(serialize(strong)).toMatchInlineSnapshot(
+        `"HTMLElement(<strong></strong>)"`,
+      );
+    });
+
+    it("HTMLElement (small)", () => {
+      const small = document.createElement("small");
+      expect(serialize(small)).toMatchInlineSnapshot(
+        `"HTMLElement(<small></small>)"`,
+      );
+    });
+
+    it("HTMLElement (mark)", () => {
+      const mark = document.createElement("mark");
+      expect(serialize(mark)).toMatchInlineSnapshot(
+        `"HTMLElement(<mark></mark>)"`,
+      );
+    });
+
+    it("HTMLElement (del)", () => {
+      const del = document.createElement("del");
+      expect(serialize(del)).toMatchInlineSnapshot(
+        `"HTMLModElement(<del></del>)"`,
+      );
+    });
+
+    it("HTMLElement (ins)", () => {
+      const ins = document.createElement("ins");
+      expect(serialize(ins)).toMatchInlineSnapshot(
+        `"HTMLModElement(<ins></ins>)"`,
+      );
+    });
+
+    it("HTMLElement (sub)", () => {
+      const sub = document.createElement("sub");
+      expect(serialize(sub)).toMatchInlineSnapshot(
+        `"HTMLElement(<sub></sub>)"`,
+      );
+    });
+
+    it("HTMLElement (sup)", () => {
+      const sup = document.createElement("sup");
+      expect(serialize(sup)).toMatchInlineSnapshot(
+        `"HTMLElement(<sup></sup>)"`,
+      );
+    });
+
+    it("HTMLElement (blockquote)", () => {
+      const blockquote = document.createElement("blockquote");
+      expect(serialize(blockquote)).toMatchInlineSnapshot(
+        `"HTMLQuoteElement(<blockquote></blockquote>)"`,
+      );
+    });
+
+    it("HTMLElement (cite)", () => {
+      const cite = document.createElement("cite");
+      expect(serialize(cite)).toMatchInlineSnapshot(
+        `"HTMLElement(<cite></cite>)"`,
+      );
+    });
+
+    it("HTMLElement (q)", () => {
+      const q = document.createElement("q");
+      expect(serialize(q)).toMatchInlineSnapshot(`"HTMLQuoteElement(<q></q>)"`);
+    });
+
+    it("HTMLElement (abbr)", () => {
+      const abbr = document.createElement("abbr");
+      expect(serialize(abbr)).toMatchInlineSnapshot(
+        `"HTMLElement(<abbr></abbr>)"`,
+      );
+    });
+
+    it("HTMLElement (address)", () => {
+      const address = document.createElement("address");
+      expect(serialize(address)).toMatchInlineSnapshot(
+        `"HTMLElement(<address></address>)"`,
+      );
+    });
+  });
+
+  describe("Other", () => {
+    it("HTMLTimeElement", () => {
+      const time = document.createElement("time");
+      expect(serialize(time)).toMatchInlineSnapshot(
+        `"HTMLTimeElement(<time></time>)"`,
+      );
+    });
+
+    it("HTMLProgressElement", () => {
+      const progress = document.createElement("progress");
+      expect(serialize(progress)).toMatchInlineSnapshot(
+        `"HTMLProgressElement(<progress></progress>)"`,
+      );
+    });
+
+    it("HTMLCollection", () => {
+      const div = document.createElement("div");
+      div.innerHTML = "<span>hello</span><span>world</span>";
+      const collection = div.children;
+      expect(serialize(collection)).toMatchInlineSnapshot(
+        `"HTMLCollection[HTMLSpanElement(<span>hello</span>),HTMLSpanElement(<span>world</span>)]"`,
+      );
+    });
+
+    it("HTMLDocument", () => {
+      const doc = document;
+      expect(serialize(doc)).toMatchInlineSnapshot(
+        `"HTMLDocument[HTMLHtmlElement(<html><head></head><body></body></html>)]"`,
+      );
+    });
+
+    it("DocumentFragment", () => {
+      const fragment = document.createDocumentFragment();
+      fragment.append(document.createElement("div"));
+      fragment.append(document.createElement("input"));
+      expect(serialize(fragment)).toMatchInlineSnapshot(
+        `"DocumentFragment[HTMLDivElement(<div></div>),HTMLInputElement(<input>)]"`,
+      );
+    });
+
+    it("Text", () => {
+      const text = document.createTextNode("Hello");
+      expect(serialize(text)).toMatchInlineSnapshot(`"Text('Hello')"`);
+    });
+
+    it("Comment", () => {
+      const comment = document.createComment("Hello");
+      expect(serialize(comment)).toMatchInlineSnapshot(`"Comment('Hello')"`);
+    });
+
+    it("NodeList", () => {
+      const div = document.createElement("div");
+      div.innerHTML = "<span>hello</span><span>world</span>";
+      const nodeList = div.querySelectorAll("span");
+      expect(serialize(nodeList)).toMatchInlineSnapshot(
+        `"NodeList[HTMLSpanElement(<span>hello</span>),HTMLSpanElement(<span>world</span>)]"`,
+      );
+    });
+
+    it("Range", () => {
+      const range = document.createRange();
+      const body = document.createElement("body");
+      body.innerHTML = "<div>hello</div><div>world</div>";
+      range.setStart(body.firstChild!.firstChild!, 1);
+      range.setEnd(body.lastChild!.firstChild!, 3);
+      expect(serialize(range)).toMatchInlineSnapshot(
+        `"Range(Text('hello'):1,Text('world'):3)"`,
+      );
+    });
+  });
+});

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -204,7 +204,10 @@ describe("serialize", () => {
     it("object", () => {
       expect(serialize({ a: 1, b: 2 })).toMatchInlineSnapshot(`"{a:1,b:2}"`);
       expect(serialize({ b: 2, a: 1 })).toMatchInlineSnapshot(`"{a:1,b:2}"`);
-      expect(serialize(Object.create(null))).toBe("{}");
+      expect(serialize(Object.create(null))).toMatchInlineSnapshot(`"{}"`);
+      expect(serialize({ outerHTML: "foo" })).toMatchInlineSnapshot(
+        `"{outerHTML:'foo'}"`,
+      );
     });
 
     it("symbol key", () => {


### PR DESCRIPTION
Resolves https://github.com/unjs/ohash/issues/154

Added support for serializing HTML elements.

We could also support these (??):
- `Comment`
- `DocumentFragment`
- `HTMLDocument`
- `HTMLCollection`
- `NodeList`
- `Range`
- `Text`

Added DOM tests with `@vitest-environment happy-dom`