### PR TITLE
fix(serialize): make key comparison locale-independent

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -39,17 +39,16 @@ const Serializer = /*@__PURE__*/ (function () {
       const typeB = typeof b;
 
       if (typeA === "string" && typeB === "string") {
-        return a.localeCompare(b);
+        return a < b ? -1 : (a > b ? 1 : 0);
       }
 
       if (typeA === "number" && typeB === "number") {
         return a - b;
       }
 
-      return String.prototype.localeCompare.call(
-        this.serialize(a, true),
-        this.serialize(b, true),
-      );
+      const serA = this.serialize(a, true);
+      const serB = this.serialize(b, true);
+      return serA < serB ? -1 : (serA > serB ? 1 : 0);
     }
 
     serialize(value: any, noQuotes?: boolean): string {
@@ -107,7 +106,9 @@ const Serializer = /*@__PURE__*/ (function () {
         );
       }
 
-      const keys = Object.keys(object).sort((a, b) => a.localeCompare(b));
+      const keys = Object.keys(object).sort((a, b) =>
+        a < b ? -1 : (a > b ? 1 : 0),
+      );
       let content = `${objName}{`;
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -98,7 +98,7 @@ describe("serialize", () => {
       map.set({ x: 42 }, "3");
 
       expect(serialize(map)).toMatchInlineSnapshot(
-        `"Map{{x:42}:'3',1:4,2:3,a:'1',z:2}"`,
+        `"Map{1:4,2:3,a:'1',z:2,{x:42}:'3'}"`,
       );
     });
   });

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { serialize } from "../src";
 
 describe("serialize", () => {
@@ -491,6 +491,38 @@ describe("serialize", () => {
 
       expect(serialize(refs)).toMatchInlineSnapshot(`"${serialize(simple)}"`);
     });
+  });
+});
+
+describe("locale independence", () => {
+  const originalLocaleCompare = String.prototype.localeCompare;
+
+  function mockLocale(locale: string) {
+    vi.spyOn(String.prototype, "localeCompare").mockImplementation(function (
+      this: string,
+      other: string,
+    ) {
+      return originalLocaleCompare.call(this, other, locale);
+    });
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should produce consistent key ordering across locales", () => {
+    const obj = { checkin: 1, destination: 2 };
+
+    // standard lexicographic order
+    mockLocale("en");
+    const serializedEn = serialize(obj);
+    vi.restoreAllMocks();
+
+    // `ch` is a digraph sorting after `d`
+    mockLocale("sk");
+    const serializedSk = serialize(obj);
+
+    expect(serializedEn).toBe(serializedSk);
   });
 });
 


### PR DESCRIPTION
fix https://github.com/nuxt/nuxt/issues/34236
fix https://github.com/unjs/ohash/issues/177

This PR aims to solve a problem with the result of `serialize()` being locale-dependent, which was introduced in https://github.com/unjs/ohash/pull/113.


<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
