### PR TITLE
fix: use locale-independent comparison for deterministic serialization (#177)

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -39,17 +39,16 @@ const Serializer = /*@__PURE__*/ (function () {
       const typeB = typeof b;
 
       if (typeA === "string" && typeB === "string") {
-        return a.localeCompare(b);
+        return a < b ? -1 : a > b ? 1 : 0;
       }
 
       if (typeA === "number" && typeB === "number") {
         return a - b;
       }
 
-      return String.prototype.localeCompare.call(
-        this.serialize(a, true),
-        this.serialize(b, true),
-      );
+      const sa = this.serialize(a, true);
+      const sb = this.serialize(b, true);
+      return sa < sb ? -1 : sa > sb ? 1 : 0;
     }
 
     serialize(value: any, noQuotes?: boolean): string {
@@ -107,7 +106,7 @@ const Serializer = /*@__PURE__*/ (function () {
         );
       }
 
-      const keys = Object.keys(object).sort((a, b) => a.localeCompare(b));
+      const keys = Object.keys(object).sort((a, b) => a < b ? -1 : a > b ? 1 : 0);
       let content = `${objName}{`;
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -39,7 +39,7 @@ const Serializer = /*@__PURE__*/ (function () {
       const typeB = typeof b;
 
       if (typeA === "string" && typeB === "string") {
-        return a < b ? -1 : a > b ? 1 : 0;
+        return a < b ? -1 : (a > b ? 1 : 0);
       }
 
       if (typeA === "number" && typeB === "number") {
@@ -48,7 +48,7 @@ const Serializer = /*@__PURE__*/ (function () {
 
       const sa = this.serialize(a, true);
       const sb = this.serialize(b, true);
-      return sa < sb ? -1 : sa > sb ? 1 : 0;
+      return sa < sb ? -1 : (sa > sb ? 1 : 0);
     }
 
     serialize(value: any, noQuotes?: boolean): string {
@@ -106,7 +106,7 @@ const Serializer = /*@__PURE__*/ (function () {
         );
       }
 
-      const keys = Object.keys(object).sort((a, b) => a < b ? -1 : a > b ? 1 : 0);
+      const keys = Object.keys(object).sort((a, b) => a < b ? -1 : (a > b ? 1 : 0));
       let content = `${objName}{`;
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];


### PR DESCRIPTION
### 🔗 Linked issue

Closes #177

### 📝 Description

`serialize()` uses `String.localeCompare()` for sorting object keys, which produces **different results depending on the system locale**.

In Slovak (sk-SK), the digraph `ch` is treated as a distinct letter after `h`. So `{checkIn: 'foo', destination: 'bar'}` serializes as `{destination:'bar',checkIn:'foo'}` in Slovak, but `{checkIn:'foo',destination:'bar'}` in English. This causes `hash()` to produce different values for the same input on different machines.

The same issue affects `Set` sorting and the `compare()` fallback path.

### Fix

Replace all `localeCompare` calls with code-point comparison (`a < b ? -1 : a > b ? 1 : 0`) which is deterministic across all locales:

1. **`compare()` for strings** — `a.localeCompare(b)` → `a < b ? -1 : a > b ? 1 : 0`
2. **`compare()` fallback** — `String.prototype.localeCompare.call(...)` → code-point compare on serialized values
3. **`Object.keys()` sort** — `a.localeCompare(b)` → code-point compare

Code-point comparison uses UTF-16 code unit values, which is stable and locale-independent.

### Impact

Without this fix, `hash()` produces different values for the same input depending on the system's `LANG`/`LC_ALL` setting. This breaks caching, content deduplication, and any system that relies on hash stability across environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal string comparison and object key sorting to use direct comparisons instead of locale-based calls.
  * Added caching for serialized values during mixed-type comparisons to reduce repeated work and improve performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->