### PR TITLE
fix(serialize): use locale-independent string comparison consistently

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -108,7 +108,7 @@ const Serializer = /*@__PURE__*/ (function () {
         );
       }
 
-      const keys = Object.keys(object).sort((a, b) => a.localeCompare(b));
+      const keys = Object.keys(object).sort((a, b) => a.localeCompare(b, "en"));
       let content = `${objName}{`;
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -39,7 +39,7 @@ const Serializer = /*@__PURE__*/ (function () {
       const typeB = typeof b;
 
       if (typeA === "string" && typeB === "string") {
-        return a.localeCompare(b);
+        return a.localeCompare(b, "en");
       }
 
       if (typeA === "number" && typeB === "number") {
@@ -49,6 +49,7 @@ const Serializer = /*@__PURE__*/ (function () {
       return String.prototype.localeCompare.call(
         this.serialize(a, true),
         this.serialize(b, true),
+        "en",
       );
     }
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -494,6 +494,57 @@ describe("serialize", () => {
   });
 });
 
+describe("locale-independent key sorting", () => {
+  let originalLocaleCompare: typeof String.prototype.localeCompare;
+  let calls: Array<{ locale: unknown }>;
+
+  beforeEach(() => {
+    originalLocaleCompare = String.prototype.localeCompare;
+    calls = [];
+    // eslint-disable-next-line no-extend-native
+    String.prototype.localeCompare = function (
+      that: string,
+      locales?: string | string[],
+      options?: Intl.CollatorOptions,
+    ) {
+      calls.push({ locale: locales });
+      return originalLocaleCompare.call(this, that, locales, options);
+    };
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line no-extend-native
+    String.prototype.localeCompare = originalLocaleCompare;
+  });
+
+  it("sorts plain object keys with explicit 'en' locale", () => {
+    serialize({ b: 1, a: 2, ch: 3, c: 4 });
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.locale).toBe("en");
+    }
+  });
+
+  it("compares Set members with explicit 'en' locale", () => {
+    serialize(new Set(["b", "a", "ch", "c"]));
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.locale).toBe("en");
+    }
+  });
+
+  it("compares mixed-type Map keys with explicit 'en' locale", () => {
+    const map = new Map<any, any>();
+    map.set({ a: 1 }, "x");
+    map.set("a", "y");
+    serialize(map);
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.locale).toBe("en");
+    }
+  });
+});
+
 // https://github.com/cloudflare/workerd/issues/3641
 describe("Object.prototype.toString issues", () => {
   let originalToString: any;


### PR DESCRIPTION
## Summary
Fixed locale-dependent string comparison in `serialize()` that caused `hash()` to produce inconsistent results across different system locales.

## Root cause
`String.prototype.localeCompare()` without a locale parameter is sensitive to the system locale. In some locales (e.g. Slovak), character combinations like "ch" are treated as distinct letters, causing different sort order and therefore different hash results for identical input.

## Fix
Pass `"en"` as the locale parameter to `localeCompare()` calls in the `compare` method, ensuring consistent string comparison regardless of system locale.

Closes #177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made serialization deterministic across locales by enforcing a consistent locale for string comparisons and key sorting, reducing environment-dependent ordering differences.
* **Tests**
  * Added tests to validate locale-independent sorting and comparison during serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ohash/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->