### PR TITLE
fix(diff): handle `false` values in `_toHashedObject`

### DIFF
--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -43,7 +43,7 @@ function _diff(h1: DiffHashedObject, h2: DiffHashedObject): DiffEntry[] {
 }
 
 function _toHashedObject(obj: any, key = ""): DiffHashedObject {
-  if (obj && typeof obj !== "object") {
+  if (obj !== null && typeof obj !== "object") {
     return new DiffHashedObject(key, obj, serialize(obj));
   }
   const props: Record<string, DiffHashedObject> = {};

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -48,4 +48,24 @@ describe("diff", () => {
       ]
     `);
   });
+
+  it("regression: false value should not render as {} in diff", () => {
+    const obj1 = { a: false };
+    const obj2 = { a: true };
+    expect(diff(obj1, obj2)).toMatchInlineSnapshot(`
+      [
+        "Changed \`a\` from \`false\` to \`true\`",
+      ]
+    `);
+  });
+
+  it("regression: zero value should not be treated as empty", () => {
+    const obj1 = { a: 0 };
+    const obj2 = { a: 1 };
+    expect(diff(obj1, obj2)).toMatchInlineSnapshot(`
+      [
+        "Changed \`a\` from \`0\` to \`1\`",
+      ]
+    `);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes `_toHashedObject` incorrectly serializing `false` values as `{}` — `typeof false === 'object'` was handling falsy objects incorrectly.

## Changes

- `src/utils.ts`: Added explicit `=== null` check instead of `!val` so that `false` (valid value) is not treated as an object

## Why

```js
hash({ a: false })  // incorrectly treated a=false as null/undefined object
// Before: hash includes a as {} -> wrong hash
// After: hash includes a as false -> correct hash
```

Closes #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed diff rendering to properly display changes involving falsy values (such as `false` and `0`) instead of treating them as empty.

* **Tests**
  * Added regression tests to verify correct diff display for boolean and numeric falsy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->