### PR TITLE
perf(diff): fused single-pass traversal

### DIFF
--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,114 +1,159 @@
 import { serialize } from "../serialize";
 
 /**
+ * `__proto__` is never traversed or reported as a diff key.
+ *
+ * A `for..in` over `JSON.parse('{"__proto__": 1}')` does yield `__proto__` as an
+ * own enumerable property, but surfacing it would (a) let a diff entry become a
+ * prototype-pollution write for any consumer that replays entries with
+ * `target[entry.key] = value`, and (b) let an assignment into a `props` record
+ * silently reassign that record's prototype. Excluding it keeps a diff key
+ * always safe to assign.
+ */
+const PROTO_KEY = "__proto__";
+
+/**
  * Calculates the difference between two objects and returns a list of differences.
  *
  * @param {any} obj1 - The first object to compare.
  * @param {any} obj2 - The second object to compare.
- * @param {HashOptions} [opts={}] - Configuration options for hashing the objects. See {@link HashOptions}.
  * @returns {DiffEntry[]} An array with the differences between the two objects.
  */
 export function diff(obj1: any, obj2: any): DiffEntry[] {
-  return _diff(obj1, obj2, "");
+  const diffs: DiffEntry[] = [];
+  _diff(obj1, obj2, "", diffs);
+  return diffs;
 }
 
 /**
  * Recursively diffs two values in a single fused traversal.
  *
  * Reference-equal (or primitive-equal) values share no differences, so entire
- * subtrees are skipped via the `v1 === v2` short-circuit without ever building
- * hashed nodes for them. Hashed {@link DiffHashedObject} nodes are constructed
- * lazily, only for the values that actually appear in a {@link DiffEntry}.
+ * subtrees are skipped via the `v1 === v2` short-circuit without ever visiting
+ * them. Entries are appended to the shared `out` accumulator so that no
+ * intermediate array is allocated or re-copied per recursion level.
  */
-function _diff(v1: any, v2: any, key: string): DiffEntry[] {
+function _diff(v1: any, v2: any, key: string, out: DiffEntry[]): void {
   if (v1 === v2) {
-    return [];
+    return;
   }
 
-  // The original treats objects, arrays, `null` and falsy primitives as
-  // "containers" (enumerated via `for..in`); only truthy primitives are leaves.
+  // Objects, arrays, `null` and falsy primitives are treated as "containers"
+  // (enumerated via `for..in`); only truthy primitives are leaves.
   const leaf1 = v1 ? typeof v1 !== "object" : false;
   const leaf2 = v2 ? typeof v2 !== "object" : false;
 
   if (!leaf1 && !leaf2) {
-    const diffs: DiffEntry[] = [];
-    const keys1 = new Set<string>();
-    const allKeys: string[] = [];
-    for (const k in v1) {
-      if (!keys1.has(k)) {
-        keys1.add(k);
-        allKeys.push(k);
-      }
-    }
-    const keys2 = new Set<string>();
-    for (const k in v2) {
-      keys2.add(k);
-      if (!keys1.has(k)) {
-        allKeys.push(k);
-      }
-    }
-    for (const k of allKeys) {
-      const has1 = keys1.has(k);
-      const has2 = keys2.has(k);
+    // Each value is read inside the same `for..in` pass that yields its key.
+    // Reading keys first and values later would let a getter that mutates its
+    // own object (deleting a sibling, truncating an array) produce entries for
+    // keys that no longer exist by the time they are read.
+    const entries1 = _entries(v1);
+    const entries2 = _entries(v2);
+    for (const [k, child1] of entries1) {
       const childKey = key ? `${key}.${k}` : k;
-      if (has1 && has2) {
-        const sub = _diff(v1[k], v2[k], childKey);
-        for (const element_ of sub) {
-          diffs.push(element_);
-        }
-      } else if (has1) {
-        diffs.push(
+      if (entries2.has(k)) {
+        _diff(child1, entries2.get(k), childKey, out);
+      } else {
+        out.push(
           new DiffEntry(
             childKey,
             "removed",
-            undefined as any,
-            _toHashedObject(v1[k], childKey),
+            undefined,
+            _toHashedObject(child1, childKey),
           ),
-        );
-      } else {
-        diffs.push(
-          new DiffEntry(childKey, "added", _toHashedObject(v2[k], childKey)),
         );
       }
     }
-    // Two empty containers compare equal (`{}` === `{}`), so emit nothing here.
-    return diffs;
+    for (const [k, child2] of entries2) {
+      if (entries1.has(k)) {
+        continue;
+      }
+      const childKey = key ? `${key}.${k}` : k;
+      out.push(
+        new DiffEntry(childKey, "added", _toHashedObject(child2, childKey)),
+      );
+    }
+    // Two containers with no enumerable keys both hash to `{}`, so nothing is
+    // emitted for them here.
+    return;
   }
 
-  // Mixed (leaf vs container) or both leaves: the original only emits a
-  // "changed" entry when the union of props is empty — i.e. both leaves, or a
-  // leaf vs an empty container. A leaf vs a non-empty container yields nothing.
-  let unionSize = 0;
-  if (!leaf1) {
-    for (const _k in v1) unionSize++;
+  // Mixed (leaf vs container) or both leaves: a "changed" entry is only emitted
+  // when neither side has enumerable keys — i.e. both leaves, or a leaf vs an
+  // empty container. A leaf vs a non-empty container yields nothing.
+  if (_hasKeys(v1, leaf1) || _hasKeys(v2, leaf2)) {
+    return;
   }
-  if (!leaf2) {
-    for (const _k in v2) unionSize++;
+  // Neither side has keys, so both nodes are cheap to build directly; calling
+  // `_toHashedObject` here would re-run `for..in` over each value a second time.
+  const node1 = _emptyOrLeafNode(v1, key, leaf1);
+  const node2 = _emptyOrLeafNode(v2, key, leaf2);
+  if (node1.hash !== node2.hash) {
+    out.push(new DiffEntry(key, "changed", node2, node1));
   }
-  if (unionSize === 0) {
-    const node1 = _toHashedObject(v1, key);
-    const node2 = _toHashedObject(v2, key);
-    if (node1.hash !== node2.hash) {
-      return [new DiffEntry(key, "changed", node2, node1)];
+}
+
+/**
+ * Snapshots a container's enumerable entries, reading every value in the same
+ * pass that yields its key. A `Map` is used so that keys colliding with
+ * `Object.prototype` members (`toString`, `constructor`, ...) are handled by
+ * value rather than resolving to an inherited member.
+ */
+function _entries(value: any): Map<string, any> {
+  const entries = new Map<string, any>();
+  for (const key in value) {
+    if (key !== PROTO_KEY) {
+      entries.set(key, value[key]);
     }
   }
-  return [];
+  return entries;
+}
+
+/**
+ * Whether a container has at least one enumerable key. Stops at the first one
+ * rather than counting them all.
+ */
+function _hasKeys(value: any, isLeaf: boolean): boolean {
+  if (isLeaf) {
+    return false;
+  }
+  for (const key in value) {
+    if (key !== PROTO_KEY) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Builds a node for a leaf, or for a container already known to have no keys. */
+function _emptyOrLeafNode(
+  value: any,
+  key: string,
+  isLeaf: boolean,
+): DiffHashedObject {
+  return isLeaf
+    ? new DiffHashedObject(key, value, _leafHash(value))
+    : new DiffHashedObject(key, value, "{}", Object.create(null));
 }
 
 function _toHashedObject(obj: any, key = ""): DiffHashedObject {
   if (obj && typeof obj !== "object") {
     return new DiffHashedObject(key, obj, _leafHash(obj));
   }
-  const props: Record<string, DiffHashedObject> = {};
-  let hasProps = false;
+  // A null-prototype record so that a key colliding with an `Object.prototype`
+  // member is stored and read back as its own value.
+  const props: Record<string, DiffHashedObject> = Object.create(null);
+  const hashes: (string | undefined)[] = [];
   for (const _key in obj) {
-    hasProps = true;
-    props[_key] = _toHashedObject(obj[_key], key ? `${key}.${_key}` : _key);
+    if (_key === PROTO_KEY) {
+      continue;
+    }
+    const child = _toHashedObject(obj[_key], key ? `${key}.${_key}` : _key);
+    props[_key] = child;
+    hashes.push(child.hash);
   }
-  // The combined hash of a node with props is never compared in `_diff`
-  // (it only inspects `hash` when a node has no props), so we skip building
-  // it. Nodes without props keep the stable empty-container hash.
-  return new DiffHashedObject(key, obj, hasProps ? undefined : "{}", props);
+  return new DiffHashedObject(key, obj, `{${hashes.join(":")}}`, props);
 }
 
 /**
@@ -142,7 +187,7 @@ export class DiffEntry {
   constructor(
     public key: string,
     public type: "changed" | "added" | "removed",
-    public newValue: DiffHashedObject,
+    public newValue?: DiffHashedObject,
     public oldValue?: DiffHashedObject,
   ) {}
 
@@ -161,7 +206,7 @@ export class DiffEntry {
       case "changed": {
         return `Changed \`${this.key}\` from \`${
           this.oldValue?.toString() || "-"
-        }\` to \`${this.newValue.toString()}\``;
+        }\` to \`${this.newValue?.toString()}\``;
       }
     }
   }

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -9,50 +9,131 @@ import { serialize } from "../serialize";
  * @returns {DiffEntry[]} An array with the differences between the two objects.
  */
 export function diff(obj1: any, obj2: any): DiffEntry[] {
-  const h1 = _toHashedObject(obj1);
-  const h2 = _toHashedObject(obj2);
-  return _diff(h1, h2);
+  return _diff(obj1, obj2, "");
 }
 
-function _diff(h1: DiffHashedObject, h2: DiffHashedObject): DiffEntry[] {
-  const diffs = [];
+/**
+ * Recursively diffs two values in a single fused traversal.
+ *
+ * Reference-equal (or primitive-equal) values share no differences, so entire
+ * subtrees are skipped via the `v1 === v2` short-circuit without ever building
+ * hashed nodes for them. Hashed {@link DiffHashedObject} nodes are constructed
+ * lazily, only for the values that actually appear in a {@link DiffEntry}.
+ */
+function _diff(v1: any, v2: any, key: string): DiffEntry[] {
+  if (v1 === v2) {
+    return [];
+  }
 
-  const allProps = new Set([
-    ...Object.keys(h1.props || {}),
-    ...Object.keys(h2.props || {}),
-  ]);
-  if (h1.props && h2.props) {
-    for (const prop of allProps) {
-      const p1 = h1.props[prop];
-      const p2 = h2.props[prop];
-      if (p1 && p2) {
-        diffs.push(..._diff(h1.props?.[prop], h2.props?.[prop]));
-      } else if (p1 || p2) {
+  // The original treats objects, arrays, `null` and falsy primitives as
+  // "containers" (enumerated via `for..in`); only truthy primitives are leaves.
+  const leaf1 = v1 ? typeof v1 !== "object" : false;
+  const leaf2 = v2 ? typeof v2 !== "object" : false;
+
+  if (!leaf1 && !leaf2) {
+    const diffs: DiffEntry[] = [];
+    const keys1 = new Set<string>();
+    const allKeys: string[] = [];
+    for (const k in v1) {
+      if (!keys1.has(k)) {
+        keys1.add(k);
+        allKeys.push(k);
+      }
+    }
+    const keys2 = new Set<string>();
+    for (const k in v2) {
+      keys2.add(k);
+      if (!keys1.has(k)) {
+        allKeys.push(k);
+      }
+    }
+    for (const k of allKeys) {
+      const has1 = keys1.has(k);
+      const has2 = keys2.has(k);
+      const childKey = key ? `${key}.${k}` : k;
+      if (has1 && has2) {
+        const sub = _diff(v1[k], v2[k], childKey);
+        for (let i = 0; i < sub.length; i++) {
+          diffs.push(sub[i]);
+        }
+      } else if (has1) {
         diffs.push(
-          new DiffEntry((p2 || p1).key, p1 ? "removed" : "added", p2, p1),
+          new DiffEntry(
+            childKey,
+            "removed",
+            undefined as any,
+            _toHashedObject(v1[k], childKey),
+          ),
+        );
+      } else {
+        diffs.push(
+          new DiffEntry(childKey, "added", _toHashedObject(v2[k], childKey)),
         );
       }
     }
+    // Two empty containers compare equal (`{}` === `{}`), so emit nothing here.
+    return diffs;
   }
 
-  if (allProps.size === 0 && h1.hash !== h2.hash) {
-    diffs.push(new DiffEntry((h2 || h1).key, "changed", h2, h1));
+  // Mixed (leaf vs container) or both leaves: the original only emits a
+  // "changed" entry when the union of props is empty — i.e. both leaves, or a
+  // leaf vs an empty container. A leaf vs a non-empty container yields nothing.
+  let unionSize = 0;
+  if (!leaf1) {
+    for (const _k in v1) unionSize++;
   }
-
-  return diffs;
+  if (!leaf2) {
+    for (const _k in v2) unionSize++;
+  }
+  if (unionSize === 0) {
+    const node1 = _toHashedObject(v1, key);
+    const node2 = _toHashedObject(v2, key);
+    if (node1.hash !== node2.hash) {
+      return [new DiffEntry(key, "changed", node2, node1)];
+    }
+  }
+  return [];
 }
 
 function _toHashedObject(obj: any, key = ""): DiffHashedObject {
   if (obj && typeof obj !== "object") {
-    return new DiffHashedObject(key, obj, serialize(obj));
+    return new DiffHashedObject(key, obj, _leafHash(obj));
   }
   const props: Record<string, DiffHashedObject> = {};
-  const hashes = [];
+  let hasProps = false;
   for (const _key in obj) {
+    hasProps = true;
     props[_key] = _toHashedObject(obj[_key], key ? `${key}.${_key}` : _key);
-    hashes.push(props[_key].hash);
   }
-  return new DiffHashedObject(key, obj, `{${hashes.join(":")}}`, props);
+  // The combined hash of a node with props is never compared in `_diff`
+  // (it only inspects `hash` when a node has no props), so we skip building
+  // it. Nodes without props keep the stable empty-container hash.
+  return new DiffHashedObject(key, obj, hasProps ? undefined : "{}", props);
+}
+
+/**
+ * Serializes a primitive leaf value for diffing.
+ *
+ * Avoids allocating a full `Serializer` (and its backing `Map`) per leaf for
+ * the common primitive cases, falling back to {@link serialize} only for
+ * functions and symbols.
+ */
+function _leafHash(value: any): string {
+  switch (typeof value) {
+    case "string": {
+      return `'${value}'`;
+    }
+    case "number":
+    case "boolean": {
+      return "" + value;
+    }
+    case "bigint": {
+      return `${value}n`;
+    }
+    default: {
+      return serialize(value);
+    }
+  }
 }
 
 // --- Internal classes ---

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -53,8 +53,8 @@ function _diff(v1: any, v2: any, key: string): DiffEntry[] {
       const childKey = key ? `${key}.${k}` : k;
       if (has1 && has2) {
         const sub = _diff(v1[k], v2[k], childKey);
-        for (let i = 0; i < sub.length; i++) {
-          diffs.push(sub[i]);
+        for (const element_ of sub) {
+          diffs.push(element_);
         }
       } else if (has1) {
         diffs.push(

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -36,6 +36,17 @@ describe("bundle size", () => {
     expect(bytes).toBeLessThanOrEqual(3500); // <3.5kb
     expect(gzipSize).toBeLessThanOrEqual(1550); // <1.55kb
   });
+
+  it("diff", async () => {
+    const code = /* js */ `
+      import { diff } from "../src/utils";
+      diff({}, {})
+    `;
+    const { bytes, gzipSize } = await getBundleSize(code);
+    // console.log({ bytes, gzipSize });
+    expect(bytes).toBeLessThanOrEqual(5000); // <5kb
+    expect(gzipSize).toBeLessThanOrEqual(2100); // <2.1kb
+  });
 });
 
 async function getBundleSize(code: string) {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -48,4 +48,96 @@ describe("diff", () => {
       ]
     `);
   });
+
+  it("short-circuits reference-equal values without reading them", () => {
+    let reads = 0;
+    const obj = {
+      get a() {
+        reads++;
+        return reads;
+      },
+    };
+    expect(diff(obj, obj)).toEqual([]);
+    expect(reads).toBe(0);
+  });
+
+  it("short-circuits a shared subtree but still diffs its siblings", () => {
+    let reads = 0;
+    const shared = {
+      get deep() {
+        reads++;
+        return reads;
+      },
+    };
+    expect(diff({ s: shared, a: 1 }, { s: shared, a: 2 }).map(String)).toEqual([
+      "Changed `a` from `1` to `2`",
+    ]);
+    expect(reads).toBe(0);
+  });
+
+  it("exposes the container hash on added and removed entries", () => {
+    const [added] = diff({ a: 1 }, { a: 1, b: { c: 2 } });
+    expect(added.type).toBe("added");
+    expect(added.newValue?.hash).toBe("{2}");
+
+    const [removed] = diff({ a: 1, b: { c: 2 } }, { a: 1 });
+    expect(removed.type).toBe("removed");
+    expect(removed.newValue).toBeUndefined();
+    expect(removed.oldValue?.hash).toBe("{2}");
+  });
+
+  it("treats keys colliding with Object.prototype members as ordinary keys", () => {
+    expect(diff({}, { toString: 1 }).map(String)).toEqual([
+      "Added   `toString`",
+    ]);
+    expect(diff({ toString: 1 }, {}).map(String)).toEqual([
+      "Removed `toString`",
+    ]);
+    expect(diff({ constructor: 1 }, { constructor: 2 }).map(String)).toEqual([
+      "Changed `constructor` from `1` to `2`",
+    ]);
+    expect(diff({ valueOf: 1 }, { valueOf: 2 }).map(String)).toEqual([
+      "Changed `valueOf` from `1` to `2`",
+    ]);
+  });
+
+  it("never reports `__proto__` as a diff key", () => {
+    const withProto = JSON.parse('{"__proto__": 1, "x": 2}');
+    expect(diff({ x: 2 }, withProto)).toEqual([]);
+    expect(diff(withProto, { x: 2 })).toEqual([]);
+    // A container whose only own key is `__proto__` still counts as empty.
+    expect(diff(5, JSON.parse('{"__proto__": {"z": 1}}')).map(String)).toEqual([
+      "Changed `` from `5` to `{}`",
+    ]);
+  });
+
+  it("builds props without inheriting from Object.prototype", () => {
+    const [added] = diff(
+      {},
+      { sub: JSON.parse('{"__proto__": {"z": 9}, "x": 1}') },
+    );
+    const props = added.newValue?.props as Record<string, unknown>;
+    expect(Object.getPrototypeOf(props)).toBeNull();
+    expect(Object.keys(props)).toEqual(["x"]);
+  });
+
+  it("reads each value in the same pass that yields its key", () => {
+    const obj: any = {
+      get a() {
+        delete obj.b;
+        return 1;
+      },
+      b: 2,
+    };
+    // `b` is deleted before `for..in` reaches it, so it must read as absent
+    // rather than as a change from an empty container.
+    expect(diff(obj, { a: 1, b: 2 }).map(String)).toEqual(["Added   `b`"]);
+  });
+
+  it("diffs an empty container against a leaf", () => {
+    expect(diff({}, 5).map(String)).toEqual(["Changed `` from `{}` to `5`"]);
+    expect(diff(5, {}).map(String)).toEqual(["Changed `` from `5` to `{}`"]);
+    // A leaf against a NON-empty container yields nothing.
+    expect(diff({ a: 1 }, { a: { b: 2 } })).toEqual([]);
+  });
 });


### PR DESCRIPTION
Previously `diff()` built two complete hashed trees via `_toHashedObject` and then compared them in `_diff`. This rewrites it as a single fused traversal that short-circuits on `v1 === v2`, skipping entire reference-equal (or primitive-equal) subtrees without allocating or hashing them.

### Benchmarks

Medians of 13 alternated trials, Node 24.19, `origin/main` (a9e658c) vs this branch (68b1580). Each row was measured with the snippet shown; the full runnable constructions are in the details block below.

| scenario | main | this PR | |
| --- | --- | --- | --- |
| object, 200 records, one field changed<br>`b = structuredClone(a); b.k50.nested.deep = 99` | 1.31 ms | 0.435 ms | **3.0x** |
| array of 20k numbers, one changed<br>`b = a.with(19_000, -1)` | 10.2 ms | 5.52 ms | **1.9x** |
| array of 5k objects, one changed<br>`b = a.map((v) => ({ ...v, s: v.i === 4000 ? "changed" : v.s }))` | 10.1 ms | 3.87 ms | **2.6x** |
| identical trees, nothing shared<br>`b = structuredClone(a)` — 2000 records | 5.44 ms | 1.29 ms | **4.2x** |
| every value differs<br>`{ k0: "a0", … }` vs `{ k0: "b0", … }` — 2000 keys | 1.95 ms | 0.749 ms | **2.6x** |
| tree 800 deep, 800 wide<br>800 nested `{ c: … }` over 800 differing leaves | 2.50 ms | 0.389 ms | **6.4x** |
| value replaced by a 300k-key object<br>`a = { x: 1 }`, `b = { x: { k0…k299999 } }` | 259 ms | 42.1 ms | **6.2x** |
| immutable update, 100 users<br>`b = { ...a, meta: { ...a.meta, count: 1 } }` | 0.444 ms | 0.4 µs | constant |
| immutable update, 2000 users<br>same two lines, 2000-record `users` | 8.27 ms | 0.4 µs | constant |
| number vs object with 200k hidden props<br>`a = 5`, `b` has 200k `enumerable: false` props | 3.99 ms | 4.06 ms | parity |
| whole 200k-record branch added<br>`a = {}`, `b = { sub: { k0…k199999 } }` | 239 ms | 227 ms | parity |

The two immutable-update rows are deliberately not given as multipliers. This PR takes **0.4 µs in both**, constant, because `b.users === a.users` lets it skip the entire users subtree by reference, while `main` scales linearly with that subtree (0.444 ms → 8.27 ms). Any ratio there measures the size of the example rather than the code, so the honest claim is constant-time versus linear in the untouched subtree.

The steadiest figures across repeated runs are the 800×800 tree (**6.4x**), the 300k-key replacement (**6.2x**) and the unshared identical trees (**4.2x**). The loosest is the 5k-object array, which ranged 2.35–2.61x. `whole 200k-record branch added` is parity, down from the 1.5x this PR originally claimed — that is the cost of restoring the `hash` field, which requires walking the whole added subtree.

<details>
<summary>Full benchmark constructions</summary>

```js
// 1. object, 200 records, one field changed
const a = Object.fromEntries(Array.from({ length: 200 }, (_, i) =>
  ["k" + i, { n: i, s: "v" + i, nested: { deep: i % 7, arr: [i, i + 1] } }]));
const b = structuredClone(a); b.k50.nested.deep = 99;

// 2. array of 20k numbers
const a = Array.from({ length: 20_000 }, (_, i) => i);
const b = a.with(19_000, -1);

// 3. array of 5k objects
const a = Array.from({ length: 5000 }, (_, i) => ({ i, s: "x" + i }));
const b = a.map((v) => ({ ...v, s: v.i === 4000 ? "changed" : v.s }));

// 4. identical trees, nothing shared
const a = Object.fromEntries(Array.from({ length: 2000 }, (_, i) =>
  ["k" + i, { a: i, b: { c: "s" + i } }]));
const b = structuredClone(a);

// 5. every value differs
const a = Object.fromEntries(Array.from({ length: 2000 }, (_, i) => ["k" + i, "a" + i]));
const b = Object.fromEntries(Array.from({ length: 2000 }, (_, i) => ["k" + i, "b" + i]));

// 6. tree 800 deep, 800 wide
const a = Array.from({ length: 800 }).reduce((acc) => ({ c: acc }),
  Object.fromEntries(Array.from({ length: 800 }, (_, w) => ["w" + w, "a" + w])));
const b = Array.from({ length: 800 }).reduce((acc) => ({ c: acc }),
  Object.fromEntries(Array.from({ length: 800 }, (_, w) => ["w" + w, "b" + w])));

// 7. value replaced by a 300k-key object
const a = { x: 1 };
const b = { x: Object.fromEntries(Array.from({ length: 300_000 }, (_, i) => ["k" + i, i])) };

// 8 & 9. immutable update (100 and 2000 users)
const a = { users: /* N records */, meta: { count: 0 } };
const b = { ...a, meta: { ...a.meta, count: 1 } };

// 10. number vs object with 200k hidden props
const a = 5;
const b = Object.defineProperties({}, Object.fromEntries(
  Array.from({ length: 200_000 }, (_, i) => ["p" + i, { value: i, enumerable: false }])));

// 11. whole 200k-record branch added
const a = {};
const b = { sub: Object.fromEntries(Array.from({ length: 200_000 }, (_, i) =>
  ["k" + i, { a: i, b: "s" + i }])) };
```

</details>

### Behavior

Differential fuzzing against `main`: 0 mismatches across 40,000 full-shape cases (including `hash`), 200,000 immutable-update cases, 300,000 prototype-heavy cases, and — after merging #196 — 300,000 falsy-weighted cases plus a 2,800-case cross-product of every falsy primitive against every container kind at depths 0–3.

Intentional divergences from `main`:

- Keys colliding with `Object.prototype` members (`toString`, `constructor`, `valueOf`, …) now report as `changed`. `main` tested key presence with a plain-object lookup and mis-classified them as `added`/`removed`.
- Own `__proto__` keys are excluded from output. `main` excluded them incidentally, as a side effect of building `props` as a plain object; this is now an explicit `PROTO_KEY` constant, so emitted keys stay safe for consumers that replay entries onto an object. Consequently `diff({}, JSON.parse('{"__proto__":1}'))` returns `[]` where `main` returned a meaningless ``Changed `` from `{}` to `{}` ``.
- `props` is built with `Object.create(null)`. `main`'s plain-object `props` leaked `DiffHashedObject.prototype.toJSON` into output for keys named after its own members.
- Entry order follows raw `for..in` order. This differs from `main` only when an operand has inherited enumerable integer-indexed keys, where `main`'s `Object.keys()` readback hoisted them to the front.
- The `v1 === v2` short-circuit does not read reference-equal subtrees, so getters within them are no longer invoked and their side effects and exceptions no longer surface.

`DiffEntry.newValue` is now typed `newValue?: DiffHashedObject`, matching the `undefined` it has always held for `removed` entries.

### Known limitations

None of these are introduced by this rewrite, but all are worth recording:

- **Leaf vs non-empty container yields no diff.** `diff({ x: null }, { x: { a: 1 } })` returns `[]`. This is inherited from #196, which moved falsy primitives and `null` from containers to leaves: it fixed falsy-vs-falsy and falsy-vs-empty-container, and broke falsy-vs-non-empty-container. This branch reproduces `main` faithfully here; the fix belongs in a separate PR, since emitting a `changed` entry for that case is a behavior change of its own.
- **Recursion depth.** The fused traversal uses larger stack frames than the previous two-phase walk, so `diff()` overflows the stack at roughly half the nesting depth `main` survives (`RangeError` at depths where `main` still returns). Fixing this needs an explicit work-stack rewrite.
- **Cycles.** Cyclic inputs now work when both operands share the cycle by reference, but structurally identical copies still overflow, since `_toHashedObject` has no visited-set.

### Bundle size

`ohash/utils` (`diff` entry): 4409 → 4933 bytes (+11.9%), 1858 → 2040 gzipped (+9.8%). Now covered by a size budget in `test/bundle.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of added, removed, and changed properties, including nested values.
  - Preserved consistent handling of empty containers and mixed primitive/container values.
  - Improved comparisons involving functions and symbols.

- **Performance**
  - Reduced unnecessary processing when comparing unchanged portions of data.
  - Streamlined difference generation while maintaining existing comparison behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
