### PR TITLE
fix(utils): diff falsy primitive values

### DIFF
--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -43,7 +43,7 @@ function _diff(h1: DiffHashedObject, h2: DiffHashedObject): DiffEntry[] {
 }
 
 function _toHashedObject(obj: any, key = ""): DiffHashedObject {
-  if (obj && typeof obj !== "object") {
+  if (obj === null || typeof obj !== "object") {
     return new DiffHashedObject(key, obj, serialize(obj));
   }
   const props: Record<string, DiffHashedObject> = {};

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -48,4 +48,17 @@ describe("diff", () => {
       ]
     `);
   });
+
+  it("formats falsy primitive changes", () => {
+    expect(diff(true, false)).toMatchInlineSnapshot(`
+      [
+        "Changed \`\` from \`true\` to \`false\`",
+      ]
+    `);
+    expect(diff("value", null)).toMatchInlineSnapshot(`
+      [
+        "Changed \`\` from \`"value"\` to \`null\`",
+      ]
+    `);
+  });
 });


### PR DESCRIPTION
## Summary
- treat `false`, `0`, empty strings, and `null` as primitive diff leaves instead of object-like values
- add regression coverage for false and null primitive diff output

Fixes #175

## Validation
- `corepack pnpm vitest run test/utils.test.ts`
- `corepack pnpm lint`
- `corepack pnpm build && corepack pnpm vitest run`

Note: `corepack pnpm test:types` currently fails on this checkout because Node globals/modules such as `node:crypto`, `node:url`, and `Buffer` are not included in the active TS config types; this is unrelated to the diff change.