### PR TITLE
docs: fix diff usage example and stale opts param

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ obj2.nested.x = 123;
 delete obj2.nested.y;
 obj2.nested.bar.baz = 123;
 
-const diff = diff(obj1, obj2);
+const changes = diff(obj1, obj2);
 
-// [-] Removed nested.y
-// [~] Changed nested.bar.baz from "123" to 123
-// [+] Added   nested.x
-console.log(diff(obj1, obj2));
+// Removed `nested.y`
+// Changed `nested.bar.baz` from `"123"` to `123`
+// Added   `nested.x`
+console.log(changes.join("\n"));
 ```
 
 ## Contribute

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -5,7 +5,6 @@ import { serialize } from "../serialize";
  *
  * @param {any} obj1 - The first object to compare.
  * @param {any} obj2 - The second object to compare.
- * @param {HashOptions} [opts={}] - Configuration options for hashing the objects. See {@link HashOptions}.
  * @returns {DiffEntry[]} An array with the differences between the two objects.
  */
 export function diff(obj1: any, obj2: any): DiffEntry[] {


### PR DESCRIPTION
The `diff` example in the README shadows its own import:

```js
import { diff } from "ohash/utils";
// ...
const diff = diff(obj1, obj2);
```

Running the block as-is throws `SyntaxError: Identifier 'diff' has already been declared` before anything executes. Renamed the result to `changes`.

Two more things in the same example/util:

- the expected-output comments didn't match what actually prints: entries stringify as ``Removed `nested.y` ``, not `[-] Removed nested.y`, and `console.log` on the array prints `DiffEntry` objects rather than the changelog strings. The example now logs `changes.join("\n")` and the comments are the verbatim output of running it.
- the JSDoc for `diff()` documents a third `opts` parameter (`@param {HashOptions} [opts={}]`), but the signature is `(obj1, obj2)` and `HashOptions` isn't referenced anywhere in the file, so I dropped that line.

Checked: `pnpm lint`, `pnpm vitest --run` (74 passing), `pnpm build`, and the example runs against the built package with output matching the comments. (`pnpm test:types` fails identically on clean HEAD in my environment — node types resolution — unrelated to this change.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the `diff` example with clearer variable naming and formatted change output.
  * Revised expected output comments for accuracy.
  * Removed outdated configuration parameter documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->