### PR TITLE
feat: add back extra hashing functions (sha256 hex, murmur)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 // Hash
 export { serialize } from "./serialize";
 export { hash } from "./hash";
+export { sha256 } from "./sha256";
+export { murmur } from "./murmur";
 
 // Crypto
 export { digest } from "ohash/crypto";

--- a/src/murmur.ts
+++ b/src/murmur.ts
@@ -1,0 +1,70 @@
+/**
+ * MurmurHash3 (x86 32-bit) — a fast non-cryptographic hash that ohash v1
+ * provided and the community used. Returns the 32-bit hash as an 8-character
+ * lowercase hexadecimal string. See issue #156.
+ *
+ * Reference implementation: https://github.com/aappleby/smhasher (MurmurHash3,
+ * public domain).
+ *
+ * @param data - The input string (UTF-8 encoded before hashing).
+ * @param seed - The 32-bit seed. @default 0
+ * @returns The hash as an 8-character hex string.
+ *
+ * @example
+ * ```js
+ * murmur("hello"); // "61315335"
+ * murmur("");       // "00000000"
+ * ```
+ */
+export function murmur(data: string, seed: number = 0): string {
+  const key = new TextEncoder().encode(data);
+  const remainder = key.length & 3;
+  const bytes = key.length - remainder;
+  let h1 = seed >>> 0;
+  const c1 = 0xcc9e2d51;
+  const c2 = 0x1b873593;
+
+  let i = 0;
+  while (i < bytes) {
+    let k1 =
+      (key[i] & 0xff) |
+      ((key[i + 1] & 0xff) << 8) |
+      ((key[i + 2] & 0xff) << 16) |
+      ((key[i + 3] & 0xff) << 24);
+    i += 4;
+
+    k1 = Math.imul(k1, c1);
+    k1 = (k1 << 15) | (k1 >>> 17);
+    k1 = Math.imul(k1, c2);
+
+    h1 ^= k1;
+    h1 = (h1 << 13) | (h1 >>> 19);
+    h1 = (Math.imul(h1, 5) + 0xe6546b64) >>> 0;
+  }
+
+  let k1 = 0;
+  switch (remainder) {
+    case 3: {
+      k1 ^= (key[i + 2] & 0xff) << 16;
+    }
+    case 2: {
+      k1 ^= (key[i + 1] & 0xff) << 8;
+    }
+    case 1: {
+      k1 ^= key[i] & 0xff;
+      k1 = Math.imul(k1, c1);
+      k1 = (k1 << 15) | (k1 >>> 17);
+      k1 = Math.imul(k1, c2);
+      h1 ^= k1;
+    }
+  }
+
+  h1 ^= key.length;
+  h1 ^= h1 >>> 16;
+  h1 = Math.imul(h1, 0x85ebca6b);
+  h1 ^= h1 >>> 13;
+  h1 = Math.imul(h1, 0xc2b2ae35);
+  h1 ^= h1 >>> 16;
+
+  return (h1 >>> 0).toString(16).padStart(8, "0");
+}

--- a/src/sha256.ts
+++ b/src/sha256.ts
@@ -1,0 +1,19 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Computes the SHA-256 digest of `data` and returns it as a lowercase
+ * hexadecimal string. This is the hex variant of the base64url {@link digest};
+ * ohash v1 exposed it and the community used it, so it is provided again here.
+ * See issue #156.
+ *
+ * @param data - The string (or Buffer/TypedArray) to hash.
+ * @returns The SHA-256 hex digest.
+ *
+ * @example
+ * ```js
+ * sha256("hello"); // "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+ * ```
+ */
+export function sha256(data: string | ArrayBufferView | ArrayBuffer): string {
+  return createHash("sha256").update(data as Uint8Array).digest("hex");
+}


### PR DESCRIPTION
Closes #156.

Add sha256(data): the SHA 256 hex digest (node:crypto createHash, lowercase hex), the hex variant of the base64url digest; and murmur(data, seed=0): MurmurHash3 x86 32 bit as an 8 char lowercase hex string (pure JS, isomorphic). Both are deterministic and exported from the main index. (Subpath exports ohash/sha256 and ohash/murmur are a packaging follow up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SHA-256 hashing for strings and binary data, returning lowercase hexadecimal results.
  * Added MurmurHash3 hashing with optional seed support and consistent hexadecimal output.
  * Both hashing utilities are now available through the package’s public exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->