### PR TITLE
docs: fix diff example and document v1 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Simple object hashing, serialization and comparison utils.
 
 > [!NOTE]
-> You are on active v2 development branch. Check [v1](https://github.com/unjs/ohash/tree/v1) for old ohash v1 docs and [release notes](https://github.com/unjs/ohash/releases/tag/v2.0.1) for migration.
+> ohash v2 is the current release. For the previous API, see the [v1 branch](https://github.com/unjs/ohash/tree/v1) and the [v2.0.1 release notes](https://github.com/unjs/ohash/releases/tag/v2.0.1) for migration.
 
 ## Usage
 
@@ -126,12 +126,12 @@ obj2.nested.x = 123;
 delete obj2.nested.y;
 obj2.nested.bar.baz = 123;
 
-const diff = diff(obj1, obj2);
+const changes = diff(obj1, obj2);
 
 // [-] Removed nested.y
 // [~] Changed nested.bar.baz from "123" to 123
 // [+] Added   nested.x
-console.log(diff(obj1, obj2));
+console.log(changes);
 ```
 
 ## Contribute
@@ -148,3 +148,12 @@ Made with 💛 Published under [MIT License](./LICENSE).
 Object serialization originally based on [puleos/object-hash](https://github.com/puleos/object-hash) by [Scott Puleo](https://github.com/puleos/).
 
 sha256 implementation originally based on [brix/crypto-js](https://github.com/brix/crypto-js).
+
+## Migration from v1
+
+| v1 | v2 |
+| --- | --- |
+| `objectHash(value)` (stable digest string like `object:1:string:3:foo:...`) | `serialize(value)` for a stable string, or `hash(value)` for a SHA-256 hash |
+| `hash(value)` | Still `hash(value)` (implementation changed; output format differs) |
+
+There is no v2 helper that reproduces the exact v1 `objectHash` string format. Use `serialize` when you need a stable structural string, and `hash` when you need a short digest.


### PR DESCRIPTION
## Summary
- Fix broken `diff` example (variable shadowed the imported function)
- Clarify that v2 is the current release (not a development-only branch)
- Add a short v1 migration table (`objectHash` vs `serialize` / `hash`)

Closes #171
Closes #163

## Test plan
- [ ] README examples are copy-pasteable
- [ ] Migration notes match v2 API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release guidance to identify v2 as the current release.
  * Added migration guidance from v1 to v2, including API mapping details and compatibility notes.
  * Refined the `diff` example for clearer variable naming and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->