### PR TITLE
fix(serialize): order NaN values consistently

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -95,12 +95,9 @@ const Serializer = /*@__PURE__*/ (function () {
       const typeA = typeof a;
       const typeB = typeof b;
 
-      if (typeA === "string" && typeB === "string") {
-        return compareStrings(a, b);
-      }
-
       if (typeA === "number" && typeB === "number") {
-        return a - b;
+        // NaN - number is NaN; coerce self-inequality to order it last.
+        return a - b || +(a !== a) - +(b !== b);
       }
 
       return compareStrings(this.serialize(a, true), this.serialize(b, true));

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -89,6 +89,28 @@ describe("serialize", () => {
       );
     });
 
+    it("sorts NaN values consistently", () => {
+      const set = serialize(new Set([Number.NaN, 1]));
+      expect(set).toBe("Set[1,NaN]");
+      expect(serialize(new Set([1, Number.NaN]))).toBe(set);
+
+      const map = serialize(
+        new Map([
+          [Number.NaN, "nan"],
+          [1, "one"],
+        ]),
+      );
+      expect(map).toBe("Map{1:'one',NaN:'nan'}");
+      expect(
+        serialize(
+          new Map([
+            [1, "one"],
+            [Number.NaN, "nan"],
+          ]),
+        ),
+      ).toBe(map);
+    });
+
     it("Map", () => {
       const map = new Map();
       map.set(1, 4);


### PR DESCRIPTION
## Problem

Set and Map serialization is not deterministic when their numeric entries include NaN. The numeric comparator returns NaN for a NaN-versus-number comparison, so Array.sort treats the entries as equal and preserves insertion order:

```
serialize(new Set([Number.NaN, 1])) // "Set[NaN,1]"
serialize(new Set([1, Number.NaN])) // "Set[1,NaN]"
```

This makes stable serialization and hashes depend on how an equivalent container was populated.

## Fix

Add a deterministic NaN tie-breaker to the numeric comparator, ordering NaN after ordinary numbers. The existing string-only fast path is removed because the generic path passes primitive strings through serialize(..., true) unchanged to the same compareStrings helper; this keeps the generated bundle within the repository's existing size limits while preserving string ordering.

## Tests

- `pnpm lint` - passed
- `pnpm build` - passed
- `pnpm test:types` - passed
- `pnpm vitest --coverage` - passed; 5 files, 91 tests
- `pnpm exec vitest run test/serialize.test.ts -t "sorts NaN values consistently"` - passed
- `pnpm exec vitest run test/bundle.test.ts` - passed
- Adjacent Set/Map numeric ordering check covering NaN, infinities, zero, and ordinary numbers - passed
- `git diff --check` - passed

## Compatibility

Existing ordering for ordinary numbers and string values is preserved. Set and Map values containing NaN now have one canonical order instead of depending on insertion order. The change is limited to the comparator and regression coverage.

## Related issue

Independent reproduction; no issue is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparison handling for non-number values.
  * Ensured `NaN` values are consistently ordered during comparisons.
  * Fixed serialization of sets and maps containing `NaN`, producing stable output regardless of insertion order.

* **Tests**
  * Added coverage confirming consistent serialization for collections containing `NaN` and numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->