### PR TITLE
fix(crypto): hash strings with a lone surrogate in the JS digest

### DIFF
--- a/src/crypto/js/index.ts
+++ b/src/crypto/js/index.ts
@@ -27,6 +27,8 @@ const base64KeyStr =
 // Reusable object
 const W: number[] = [];
 
+const encoder = /*@__PURE__*/ new TextEncoder();
+
 /**
  * SHA-256 hash algorithm.
  */
@@ -194,13 +196,14 @@ class WordArray {
   }
 
   static fromUtf8(input: string) {
-    const str = unescape(encodeURIComponent(input)); // utf8 => latin1
-    const strlen = str.length;
+    const bytes = encoder.encode(input);
     const words: number[] = [];
-    for (let i = 0; i < strlen; i++) {
-      words[i >>> 2] |= (str.charCodeAt(i) & 0xff) << (24 - (i % 4) * 8);
+    let i = 0;
+    for (const byte of bytes) {
+      words[i >>> 2] |= byte << (24 - (i % 4) * 8);
+      i++;
     }
-    return new WordArray(words, strlen);
+    return new WordArray(words, bytes.length);
   }
 
   toBase64(): string {

--- a/test/crypto.test.ts
+++ b/test/crypto.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 
 import * as cryptoJS from "../src/crypto/js";
@@ -20,6 +21,15 @@ describe("crypto:digest", () => {
         );
         expect(digest("")).toBe("47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU");
       });
+
+      it.each(["\uD800", "a\uDFFFb", "\uD83D", "\uDE00\uD83D"])(
+        "matches node:crypto for the lone surrogate %j",
+        (input) => {
+          expect(digest(input)).toBe(
+            createHash("sha256").update(input, "utf8").digest("base64url"),
+          );
+        },
+      );
     });
   }
 });


### PR DESCRIPTION
The JS `digest` encoded its input with `unescape(encodeURIComponent(input))`, which throws `URIError: URI malformed` on a string containing a lone surrogate, so `hash()` crashed in browser and edge builds on input that hashes fine on Node.

It now encodes with `TextEncoder`, which substitutes U+FFFD as `node:crypto` does and produces identical bytes for well-formed input. The new tests compare four lone-surrogate inputs against `node:crypto`; they fail on main and pass with the change. Lint, types and the bundle-size test are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 handling for text containing unmatched surrogate characters.
  * SHA-256 digests now correctly match standard UTF-8 behavior for these inputs.

* **Tests**
  * Added coverage for lone and mixed surrogate code units to verify digest compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->